### PR TITLE
Widen Error Type to Throwable in ZIO Test Interop

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -49,12 +49,12 @@ lazy val interopCats = crossProject(JSPlatform, JVMPlatform)
   .settings(buildInfoSettings)
   .settings(
     libraryDependencies ++= Seq(
-      "dev.zio"       %%% "zio"                  % "1.0.0-RC12-1",
-      "dev.zio"       %%% "zio-test"             % "1.0.0-RC12-1",
+      "dev.zio"       %%% "zio"                  % "1.0.0-RC13",
+      "dev.zio"       %%% "zio-test"             % "1.0.0-RC13",
       "org.typelevel" %%% "cats-effect"          % "2.0.0" % Optional,
       "org.typelevel" %%% "cats-mtl-core"        % "0.7.0" % Optional,
       "co.fs2"        %%% "fs2-core"             % "2.0.0" % Test,
-      "dev.zio"       %%% "zio-test-sbt"         % "1.0.0-RC12-1" % Test,
+      "dev.zio"       %%% "zio-test-sbt"         % "1.0.0-RC13" % Test,
       "org.specs2"    %%% "specs2-core"          % "4.7.1" % Test,
       "org.specs2"    %%% "specs2-scalacheck"    % "4.7.1" % Test,
       "org.specs2"    %%% "specs2-matcher-extra" % "4.7.1" % Test,

--- a/interop-cats/shared/src/main/scala/zio/interop/test/CatsTestFunctions.scala
+++ b/interop-cats/shared/src/main/scala/zio/interop/test/CatsTestFunctions.scala
@@ -19,21 +19,21 @@ package zio.interop.test
 import cats.effect.Effect
 import zio.interop.catz.taskEffectInstance
 import zio.test.{ test => _, _ }
-import zio.{ Runtime, URIO, ZIO }
+import zio.{ RIO, Task }
 
 trait CatsTestFunctions {
 
   /**
    * Checks the assertion holds for the given effectfully-computed value.
    */
-  final def assertF[F[_], R, A](value: F[A], assertion: Assertion[A])(implicit F: Effect[F]): URIO[R, TestResult] =
+  final def assertF[F[_], R, A](value: F[A], assertion: Assertion[A])(implicit F: Effect[F]): RIO[R, TestResult] =
     assertM(fromEffect(value), assertion)
 
   /**
    * Checks the effectual test passes for "sufficient" numbers of samples from
    * the given random variable.
    */
-  final def checkF[F[_], R, A](rv: Gen[R, A])(test: A => F[TestResult])(implicit F: Effect[F]): URIO[R, TestResult] =
+  final def checkF[F[_], R, A](rv: Gen[R, A])(test: A => F[TestResult])(implicit F: Effect[F]): RIO[R, TestResult] =
     checkM(rv)(a => fromEffect(test(a)))
 
   /**
@@ -41,7 +41,7 @@ trait CatsTestFunctions {
    */
   final def checkF[F[_], R, A, B](rv1: Gen[R, A], rv2: Gen[R, B])(
     test: (A, B) => F[TestResult]
-  )(implicit F: Effect[F]): URIO[R, TestResult] =
+  )(implicit F: Effect[F]): RIO[R, TestResult] =
     checkM(rv1, rv2)((a, b) => fromEffect(test(a, b)))
 
   /**
@@ -49,7 +49,7 @@ trait CatsTestFunctions {
    */
   final def checkF[F[_], R, A, B, C](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C])(
     test: (A, B, C) => F[TestResult]
-  )(implicit F: Effect[F]): URIO[R, TestResult] =
+  )(implicit F: Effect[F]): RIO[R, TestResult] =
     checkM(rv1, rv2, rv3)((a, b, c) => fromEffect(test(a, b, c)))
 
   /**
@@ -57,7 +57,7 @@ trait CatsTestFunctions {
    */
   final def checkF[F[_], R, A, B, C, D](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C], rv4: Gen[R, D])(
     test: (A, B, C, D) => F[TestResult]
-  )(implicit F: Effect[F]): URIO[R, TestResult] =
+  )(implicit F: Effect[F]): RIO[R, TestResult] =
     checkM(rv1, rv2, rv3, rv4)((a, b, c, d) => fromEffect(test(a, b, c, d)))
 
   /**
@@ -65,7 +65,7 @@ trait CatsTestFunctions {
    * variable. This is useful for deterministic `Gen` that comprehensively
    * explore all possibilities in a given domain.
    */
-  final def checkAllF[F[_], R, A](rv: Gen[R, A])(test: A => F[TestResult])(implicit F: Effect[F]): URIO[R, TestResult] =
+  final def checkAllF[F[_], R, A](rv: Gen[R, A])(test: A => F[TestResult])(implicit F: Effect[F]): RIO[R, TestResult] =
     checkAllM(rv)(a => fromEffect(test(a)))
 
   /**
@@ -73,7 +73,7 @@ trait CatsTestFunctions {
    */
   final def checkAllF[F[_], R, A, B](rv1: Gen[R, A], rv2: Gen[R, B])(
     test: (A, B) => F[TestResult]
-  )(implicit F: Effect[F]): URIO[R, TestResult] =
+  )(implicit F: Effect[F]): RIO[R, TestResult] =
     checkAllM(rv1, rv2)((a, b) => fromEffect(test(a, b)))
 
   /**
@@ -81,7 +81,7 @@ trait CatsTestFunctions {
    */
   final def checkAllF[F[_], R, A, B, C](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C])(
     test: (A, B, C) => F[TestResult]
-  )(implicit F: Effect[F]): URIO[R, TestResult] =
+  )(implicit F: Effect[F]): RIO[R, TestResult] =
     checkAllM(rv1, rv2, rv3)((a, b, c) => fromEffect(test(a, b, c)))
 
   /**
@@ -89,7 +89,7 @@ trait CatsTestFunctions {
    */
   final def checkAllF[F[_], R, A, B, C, D](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C], rv4: Gen[R, D])(
     test: (A, B, C, D) => F[TestResult]
-  )(implicit F: Effect[F]): URIO[R, TestResult] =
+  )(implicit F: Effect[F]): RIO[R, TestResult] =
     checkAllM(rv1, rv2, rv3, rv4)((a, b, c, d) => fromEffect(test(a, b, c, d)))
 
   /**
@@ -98,7 +98,7 @@ trait CatsTestFunctions {
    */
   final def checkSomeF[F[_], R, A](
     rv: Gen[R, A]
-  )(n: Int)(test: A => F[TestResult])(implicit F: Effect[F]): URIO[R, TestResult] =
+  )(n: Int)(test: A => F[TestResult])(implicit F: Effect[F]): RIO[R, TestResult] =
     checkSomeM(rv)(n)(a => fromEffect(test(a)))
 
   /**
@@ -106,7 +106,7 @@ trait CatsTestFunctions {
    */
   final def checkSomeF[F[_], R, A, B](rv1: Gen[R, A], rv2: Gen[R, B])(
     n: Int
-  )(test: (A, B) => F[TestResult])(implicit F: Effect[F]): URIO[R, TestResult] =
+  )(test: (A, B) => F[TestResult])(implicit F: Effect[F]): RIO[R, TestResult] =
     checkSomeM(rv1, rv2)(n)((a, b) => fromEffect(test(a, b)))
 
   /**
@@ -114,7 +114,7 @@ trait CatsTestFunctions {
    */
   final def checkSomeF[F[_], R, A, B, C](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C])(
     n: Int
-  )(test: (A, B, C) => F[TestResult])(implicit F: Effect[F]): URIO[R, TestResult] =
+  )(test: (A, B, C) => F[TestResult])(implicit F: Effect[F]): RIO[R, TestResult] =
     checkSomeM(rv1, rv2, rv3)(n)((a, b, c) => fromEffect(test(a, b, c)))
 
   /**
@@ -122,15 +122,15 @@ trait CatsTestFunctions {
    */
   final def checkSomeF[F[_], R, A, B, C, D](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C], rv4: Gen[R, D])(
     n: Int
-  )(test: (A, B, C, D) => F[TestResult])(implicit F: Effect[F]): URIO[R, TestResult] =
+  )(test: (A, B, C, D) => F[TestResult])(implicit F: Effect[F]): RIO[R, TestResult] =
     checkSomeM(rv1, rv2, rv3, rv4)(n)((a, b, c, d) => fromEffect(test(a, b, c, d)))
 
   /**
    * Builds a spec with a single effectful test.
    */
-  final def testF[F[_], R, L](label: L)(assertion: F[TestResult])(implicit F: Effect[F]): ZSpec[R, Nothing, L, Unit] =
+  final def testF[F[_], L](label: L)(assertion: F[TestResult])(implicit F: Effect[F]): ZSpec[Any, Throwable, L, Unit] =
     testM(label)(fromEffect(assertion))
 
-  private def fromEffect[F[_], R, A](eff: F[A])(implicit F: Effect[F]): URIO[R, A] =
-    ZIO.runtime.flatMap((r: Runtime[R]) => taskEffectInstance(r).liftIO(F.toIO(eff))).orDie
+  private def fromEffect[F[_], A](eff: F[A])(implicit F: Effect[F]): Task[A] =
+    Task.runtime.flatMap(taskEffectInstance(_).liftIO(F.toIO(eff)))
 }

--- a/interop-cats/shared/src/test/scala/zio/interop/test/TestSpec.scala
+++ b/interop-cats/shared/src/test/scala/zio/interop/test/TestSpec.scala
@@ -35,7 +35,7 @@ object TestSpecUtils {
         test: ZIO[R, TestFailure[E], TestSuccess[S]]
       ): ZIO[R, TestFailure[E], TestSuccess[S]] =
         test.foldCauseM(
-          _ => ZIO.succeed(TestSuccess.Succeeded(AssertResult.unit)),
+          _ => ZIO.succeed(TestSuccess.Succeeded(BoolAlgebra.unit)),
           _ => ZIO.fail(TestFailure.Runtime(zio.Cause.die(new RuntimeException("expected failure"))))
         )
     }


### PR DESCRIPTION
When we originally implemented the interop support for ZIO Test, the test methods required the error type to be `Nothing`, so we translated any `Throwable` in the `F` effect to a `die` failure using `orDie`. Subsequently we made the test methods in ZIO Test polymorphic in the error type, so now we can stop doing that and just propagate the potential `Throwable` failure through.