### PR TITLE
Don't report fiber failure in runAsync/Cancelable for https://github.com/http4s/http4s/issues/2729

### DIFF
--- a/interop-cats/shared/src/main/scala/zio/interop/cats.scala
+++ b/interop-cats/shared/src/main/scala/zio/interop/cats.scala
@@ -167,8 +167,8 @@ private class CatsConcurrentEffect[R](rts: Runtime[R])
     cb: Either[Throwable, A] => effect.IO[Unit]
   ): effect.SyncIO[Unit] =
     effect.SyncIO {
-      rts.unsafeRunAsync(fa) { exit =>
-        cb(exit.toEither).unsafeRunAsync(_ => ())
+      rts.unsafeRunAsync(fa.run) { exit =>
+        cb(exit.flatMap(identity).toEither).unsafeRunAsync(_ => ())
       }
     }
 
@@ -187,7 +187,7 @@ private class CatsConcurrentEffect[R](rts: Runtime[R])
           )
           .interruptible
           .nonDaemon
-          .fork
+          .forkInternal
           .daemon
           .map(_.interrupt.unit)
       }


### PR DESCRIPTION
Turns out we already have `forkInternal` for this