### PR TITLE
Update to latest zio

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -47,19 +47,19 @@ lazy val interopCats = crossProject(JSPlatform, JVMPlatform)
   .settings(buildInfoSettings)
   .settings(
     libraryDependencies ++= Seq(
-      "dev.zio"       %%% "zio"                  % "1.0.0-RC17",
-      "dev.zio"       %%% "zio-streams"          % "1.0.0-RC17" % Optional,
-      "dev.zio"       %%% "zio-test"             % "1.0.0-RC17" % Optional,
-      "org.typelevel" %%% "cats-effect"          % "2.0.0" % Optional,
-      "org.typelevel" %%% "cats-mtl-core"        % "0.7.0" % Optional,
-      "co.fs2"        %%% "fs2-core"             % "2.1.0" % Test,
-      "dev.zio"       %%% "zio-test-sbt"         % "1.0.0-RC17" % Test,
-      "org.specs2"    %%% "specs2-core"          % "4.8.3" % Test,
-      "org.specs2"    %%% "specs2-scalacheck"    % "4.8.3" % Test,
-      "org.specs2"    %%% "specs2-matcher-extra" % "4.8.3" % Test,
-      "org.typelevel" %%% "cats-testkit"         % "2.0.0" % Test,
-      "org.typelevel" %%% "cats-effect-laws"     % "2.0.0" % Test,
-      "org.typelevel" %%% "cats-mtl-laws"        % "0.7.0" % Test,
+      "dev.zio"       %%% "zio"                  % zioVersion,
+      "dev.zio"       %%% "zio-streams"          % zioVersion  % Optional,
+      "dev.zio"       %%% "zio-test"             % zioVersion  % Optional,
+      "org.typelevel" %%% "cats-effect"          % "2.0.0"     % Optional,
+      "org.typelevel" %%% "cats-mtl-core"        % "0.7.0"     % Optional,
+      "co.fs2"        %%% "fs2-core"             % "2.1.0"     % Test,
+      "dev.zio"       %%% "zio-test-sbt"         % zioVersion  % Test,
+      "org.specs2"    %%% "specs2-core"          % "4.8.3"     % Test,
+      "org.specs2"    %%% "specs2-scalacheck"    % "4.8.3"     % Test,
+      "org.specs2"    %%% "specs2-matcher-extra" % "4.8.3"     % Test,
+      "org.typelevel" %%% "cats-testkit"         % "2.0.0"     % Test,
+      "org.typelevel" %%% "cats-effect-laws"     % "2.0.0"     % Test,
+      "org.typelevel" %%% "cats-mtl-laws"        % "0.7.0"     % Test,
       "org.typelevel" %%% "discipline-scalatest" % "1.0.0-RC1" % Test
     )
   )
@@ -78,8 +78,8 @@ lazy val coreOnlyTest = crossProject(JSPlatform, JVMPlatform)
   .settings(skip in publish := true)
   .settings(
     libraryDependencies ++= Seq(
-      "org.typelevel" %%% "cats-core"    % "2.0.0"      % Test,
-      "dev.zio"       %%% "zio-test-sbt" % "1.0.0-RC17" % Test
+      "org.typelevel" %%% "cats-core"    % "2.0.0"    % Test,
+      "dev.zio"       %%% "zio-test-sbt" % zioVersion % Test
     )
   )
   .settings(testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"))

--- a/build.sbt
+++ b/build.sbt
@@ -48,18 +48,18 @@ lazy val interopCats = crossProject(JSPlatform, JVMPlatform)
   .settings(
     libraryDependencies ++= Seq(
       "dev.zio"       %%% "zio"                  % zioVersion,
-      "dev.zio"       %%% "zio-streams"          % zioVersion  % Optional,
-      "dev.zio"       %%% "zio-test"             % zioVersion  % Optional,
-      "org.typelevel" %%% "cats-effect"          % "2.0.0"     % Optional,
-      "org.typelevel" %%% "cats-mtl-core"        % "0.7.0"     % Optional,
-      "co.fs2"        %%% "fs2-core"             % "2.1.0"     % Test,
-      "dev.zio"       %%% "zio-test-sbt"         % zioVersion  % Test,
-      "org.specs2"    %%% "specs2-core"          % "4.8.3"     % Test,
-      "org.specs2"    %%% "specs2-scalacheck"    % "4.8.3"     % Test,
-      "org.specs2"    %%% "specs2-matcher-extra" % "4.8.3"     % Test,
-      "org.typelevel" %%% "cats-testkit"         % "2.0.0"     % Test,
-      "org.typelevel" %%% "cats-effect-laws"     % "2.0.0"     % Test,
-      "org.typelevel" %%% "cats-mtl-laws"        % "0.7.0"     % Test,
+      "dev.zio"       %%% "zio-streams"          % zioVersion % Optional,
+      "dev.zio"       %%% "zio-test"             % zioVersion % Optional,
+      "org.typelevel" %%% "cats-effect"          % "2.0.0" % Optional,
+      "org.typelevel" %%% "cats-mtl-core"        % "0.7.0" % Optional,
+      "co.fs2"        %%% "fs2-core"             % "2.1.0" % Test,
+      "dev.zio"       %%% "zio-test-sbt"         % zioVersion % Test,
+      "org.specs2"    %%% "specs2-core"          % "4.8.3" % Test,
+      "org.specs2"    %%% "specs2-scalacheck"    % "4.8.3" % Test,
+      "org.specs2"    %%% "specs2-matcher-extra" % "4.8.3" % Test,
+      "org.typelevel" %%% "cats-testkit"         % "2.0.0" % Test,
+      "org.typelevel" %%% "cats-effect-laws"     % "2.0.0" % Test,
+      "org.typelevel" %%% "cats-mtl-laws"        % "0.7.0" % Test,
       "org.typelevel" %%% "discipline-scalatest" % "1.0.0-RC1" % Test
     )
   )

--- a/interop-cats/jvm/src/test/scala/zio/interop/CatsZManagedSyntaxSpec.scala
+++ b/interop-cats/jvm/src/test/scala/zio/interop/CatsZManagedSyntaxSpec.scala
@@ -51,7 +51,7 @@ class CatsZManagedSyntaxSpec extends Specification with AroundTimeout with Defau
 
     val testCase = {
       val managed: ZManaged[Any, Throwable, Unit] = res(1).toManaged
-      managed.use(_ => ZIO.interrupt.unit)
+      managed.use_(ZIO.interrupt.unit)
     }
 
     unsafeRun(testCase.orElse(ZIO.unit))
@@ -70,7 +70,7 @@ class CatsZManagedSyntaxSpec extends Specification with AroundTimeout with Defau
 
     val testCase = {
       val managed: ZManaged[Any, Throwable, Unit] = res(1).toManaged
-      managed.use(_ => ZIO.fail(new RuntimeException()).unit)
+      managed.use_(ZIO.fail(new RuntimeException()).unit)
     }
 
     unsafeRun(testCase.orElse(ZIO.unit))
@@ -89,7 +89,7 @@ class CatsZManagedSyntaxSpec extends Specification with AroundTimeout with Defau
 
     val testCase = {
       val managed: ZManaged[Any, Throwable, Unit] = res(1).toManaged
-      managed.use(_ => ZIO.die(new RuntimeException()).unit)
+      managed.use_(ZIO.die(new RuntimeException()).unit)
     }
 
     unsafeRun(testCase.sandbox.orElse(ZIO.unit))
@@ -105,7 +105,7 @@ class CatsZManagedSyntaxSpec extends Specification with AroundTimeout with Defau
 
     val testCase = {
       val managed: ZManaged[Any, Throwable, Unit] = res(1).toManaged
-      managed.use(_ => ZIO.unit)
+      managed.use_(ZIO.unit)
     }
 
     unsafeRun(testCase.sandbox.orElse(ZIO.unit))
@@ -119,7 +119,7 @@ class CatsZManagedSyntaxSpec extends Specification with AroundTimeout with Defau
 
     val testCase = {
       val managed: ZManaged[Any, Throwable, Unit] = res(1).toManaged
-      managed.use(_ => ZIO.unit)
+      managed.use_(ZIO.unit)
     }
 
     unsafeRun(testCase)
@@ -138,7 +138,7 @@ class CatsZManagedSyntaxSpec extends Specification with AroundTimeout with Defau
     val testCase = {
       val managed1: ZManaged[Any, Throwable, Unit] = res(1).toManaged
       val managed2: ZManaged[Any, Throwable, Unit] = man(2)
-      (managed1 *> managed2).use(_ => ZIO.unit)
+      (managed1 *> managed2).use_(ZIO.unit)
     }
 
     unsafeRun(testCase)
@@ -157,7 +157,7 @@ class CatsZManagedSyntaxSpec extends Specification with AroundTimeout with Defau
 
     val testCase = {
       val managed: ZManaged[Any, Throwable, Unit] = res(1).toManagedZIO
-      managed.use(_ => ZIO.interrupt.unit)
+      managed.use_(ZIO.interrupt.unit)
     }
 
     unsafeRun(testCase.orElse(ZIO.unit))
@@ -176,7 +176,7 @@ class CatsZManagedSyntaxSpec extends Specification with AroundTimeout with Defau
 
     val testCase = {
       val managed: ZManaged[Any, Throwable, Unit] = res(1).toManagedZIO
-      managed.use(_ => ZIO.fail(new RuntimeException()).unit)
+      managed.use_(ZIO.fail(new RuntimeException()).unit)
     }
 
     unsafeRun(testCase.orElse(ZIO.unit))
@@ -195,7 +195,7 @@ class CatsZManagedSyntaxSpec extends Specification with AroundTimeout with Defau
 
     val testCase = {
       val managed: ZManaged[Any, Throwable, Unit] = res(1).toManagedZIO
-      managed.use(_ => ZIO.die(new RuntimeException()).unit)
+      managed.use_(ZIO.die(new RuntimeException()).unit)
     }
 
     unsafeRun(testCase.sandbox.orElse(ZIO.unit))
@@ -211,7 +211,7 @@ class CatsZManagedSyntaxSpec extends Specification with AroundTimeout with Defau
 
     val testCase = {
       val managed: ZManaged[Any, Throwable, Unit] = res(1).toManagedZIO
-      managed.use(_ => ZIO.unit)
+      managed.use_(ZIO.unit)
     }
 
     unsafeRun(testCase.sandbox.orElse(ZIO.unit))
@@ -225,7 +225,7 @@ class CatsZManagedSyntaxSpec extends Specification with AroundTimeout with Defau
 
     val testCase = {
       val managed: ZManaged[Any, Throwable, Unit] = res(1).toManagedZIO
-      managed.use(_ => ZIO.unit)
+      managed.use_(ZIO.unit)
     }
 
     unsafeRun(testCase)
@@ -244,7 +244,7 @@ class CatsZManagedSyntaxSpec extends Specification with AroundTimeout with Defau
     val testCase = {
       val managed1: ZManaged[Any, Throwable, Unit] = res(1).toManagedZIO
       val managed2: ZManaged[Any, Throwable, Unit] = man(2)
-      (managed1 *> managed2).use(_ => ZIO.unit)
+      (managed1 *> managed2).use_(ZIO.unit)
     }
 
     unsafeRun(testCase)
@@ -300,7 +300,7 @@ class CatsZManagedSyntaxSpec extends Specification with AroundTimeout with Defau
 
   def toResourceCancelableReservationAcquisition =
     unsafeRun {
-      ZIO.runtime[Any] >>= { implicit runtime =>
+      ZIO.runtime[Unit] >>= { implicit runtime =>
         implicit val ctx: ContextShift[CIO] = CIO.contextShift(global)
 
         for {
@@ -326,7 +326,7 @@ class CatsZManagedSyntaxSpec extends Specification with AroundTimeout with Defau
                   )
                   .unsafeRunSync()
               }
-          _   <- endLatch.await.timeout(zio.duration.Duration(10, TimeUnit.SECONDS))
+          _   <- endLatch.await.timeout(zio.duration.Duration(10, TimeUnit.SECONDS)).provideLayer(ZEnv.live)
           res <- release.get
         } yield res must_=== true
       }

--- a/interop-cats/jvm/src/test/scala/zio/interop/Fs2ZioSpec.scala
+++ b/interop-cats/jvm/src/test/scala/zio/interop/Fs2ZioSpec.scala
@@ -67,7 +67,7 @@ class ZioWithFs2Spec(implicit ee: ExecutionEnv) extends Specification with Aroun
         _ <- started.await
         _ <- fail.succeed(())
         _ <- released.await
-      } yield ()).timeout(10.seconds)
+      } yield ()).timeout(10.seconds).provideLayer(ZEnv.live)
     } must beSome(())
 
   def bracketTerminate =
@@ -88,7 +88,7 @@ class ZioWithFs2Spec(implicit ee: ExecutionEnv) extends Specification with Aroun
         _ <- started.await
         _ <- terminate.succeed(())
         _ <- released.await
-      } yield ()).timeout(10.seconds)
+      } yield ()).timeout(10.seconds).provideLayer(ZEnv.live)
     } must beSome(())
 
   def bracketInterrupt =
@@ -106,7 +106,7 @@ class ZioWithFs2Spec(implicit ee: ExecutionEnv) extends Specification with Aroun
         _ <- started.await
         _ <- f.interrupt
         _ <- released.await
-      } yield ()).timeout(10.seconds)
+      } yield ()).timeout(10.seconds).provideLayer(ZEnv.live)
     } must beSome(())
 
   def testCaseJoin[F[_]: Concurrent]: F[List[Int]] = {

--- a/interop-cats/shared/src/main/scala/zio/interop/stm/STM.scala
+++ b/interop-cats/shared/src/main/scala/zio/interop/stm/STM.scala
@@ -29,51 +29,51 @@ final class STM[F[+_], +A] private[stm] (private[stm] val underlying: ZSTM[Throw
   self =>
 
   /**
-   * See `<*>` [[zio.stm.STM]] `<*>`
+   * See `<*>` [[zio.stm.ZSTM]] `<*>`
    */
   final def <*>[B](that: => STM[F, B]): STM[F, (A, B)] =
     self zip that
 
   /**
-   * See [[zio.stm.STM]] `<*`
+   * See [[zio.stm.ZSTM]] `<*`
    */
   final def <*[B](that: => STM[F, B]): STM[F, A] =
     self zipLeft that
 
   /**
-   * See [[zio.stm.STM]] `*>`
+   * See [[zio.stm.ZSTM]] `*>`
    */
   final def *>[B](that: => STM[F, B]): STM[F, B] =
     self zipRight that
 
   /**
-   * See [[zio.stm.STM]] `>>=`
+   * See [[zio.stm.ZSTM]] `>>=`
    */
   final def >>=[B](f: A => STM[F, B]): STM[F, B] =
     self flatMap f
 
   /**
-   * See [[zio.stm.STM#collect]]
+   * See [[zio.stm.ZSTM#as]]
+   */
+  final def as[B](b: => B): STM[F, B] = self map (_ => b)
+
+  /**
+   * See [[zio.stm.ZSTM#collect]]
    */
   final def collect[B](pf: PartialFunction[A, B]): STM[F, B] = new STM(underlying.collect(pf))
 
   /**
-   * See [[zio.stm.STM#commit]]
+   * See [[zio.stm.ZSTM#commit]]
    */
   final def commit(implicit R: Runtime[Any], A: Async[F]): F[A] = STM.atomically(self)
 
   /**
-   * See [[zio.stm.STM#const]]
-   */
-  final def const[B](b: => B): STM[F, B] = self map (_ => b)
-
-  /**
-   * See [[zio.stm.STM#either]]
+   * See [[zio.stm.ZSTM#either]]
    */
   final def either: STM[F, Either[Throwable, A]] = new STM(underlying.either)
 
   /**
-   * See [[zio.stm.STM#filter]]
+   * See [[zio.stm.ZSTM#filter]]
    */
   final def filter(f: A => Boolean): STM[F, A] =
     collect {
@@ -81,34 +81,34 @@ final class STM[F[+_], +A] private[stm] (private[stm] val underlying: ZSTM[Throw
     }
 
   /**
-   * See [[zio.stm.STM#flatMap]]
+   * See [[zio.stm.ZSTM#flatMap]]
    */
   final def flatMap[B](f: A => STM[F, B]): STM[F, B] = new STM(underlying.flatMap(f.andThen(_.underlying)))
 
   /**
-   * See [[zio.stm.STM#flatten]]
+   * See [[zio.stm.ZSTM#flatten]]
    */
   final def flatten[B](implicit ev: A <:< STM[F, B]): STM[F, B] =
     self flatMap ev
 
   /**
-   * See [[zio.stm.STM#fold]]
+   * See [[zio.stm.ZSTM#fold]]
    */
   final def fold[B](f: Throwable => B, g: A => B): STM[F, B] = new STM(underlying.fold(f, g))
 
   /**
-   * See [[zio.stm.STM#foldM]]
+   * See [[zio.stm.ZSTM#foldM]]
    */
   final def foldM[B](f: Throwable => STM[F, B], g: A => STM[F, B]): STM[F, B] =
     new STM(underlying.foldM(f.andThen(_.underlying), g.andThen(_.underlying)))
 
   /**
-   * See [[zio.stm.STM#map]]
+   * See [[zio.stm.ZSTM#map]]
    */
   final def map[B](f: A => B): STM[F, B] = new STM(underlying.map(f))
 
   /**
-   * See [[zio.stm.STM#mapError]]
+   * See [[zio.stm.ZSTM#mapError]]
    */
   final def mapError[E1 <: Throwable](f: Throwable => E1): STM[F, A] = new STM(underlying.mapError(f))
 
@@ -118,29 +118,29 @@ final class STM[F[+_], +A] private[stm] (private[stm] val underlying: ZSTM[Throw
   final def mapK[G[+_]]: STM[G, A] = new STM(underlying)
 
   /**
-   * See [[zio.stm.STM#option]]
+   * See [[zio.stm.ZSTM#option]]
    */
   final def option: STM[F, Option[A]] =
     fold[Option[A]](_ => None, Some(_))
 
   /**
-   * See [[zio.stm.STM#orElse]]
+   * See [[zio.stm.ZSTM#orElse]]
    */
   final def orElse[A1 >: A](that: => STM[F, A1]): STM[F, A1] = new STM(underlying.orElse(that.underlying))
 
   /**
-   * See [[zio.stm.STM#orElseEither]]
+   * See [[zio.stm.ZSTM#orElseEither]]
    */
   final def orElseEither[B](that: => STM[F, B]): STM[F, Either[A, B]] =
     (self map (Left[A, B](_))) orElse (that map (Right[A, B](_)))
 
   /**
-   * See zio.stm.STM.unit
+   * See zio.stm.ZSTM.unit
    */
-  final def unit: STM[F, Unit] = const(())
+  final def unit: STM[F, Unit] = as(())
 
   /**
-   * See zio.stm.STM.unit
+   * See zio.stm.ZSTM.unit
    */
   final def void: STM[F, Unit] = unit
 
@@ -150,25 +150,25 @@ final class STM[F[+_], +A] private[stm] (private[stm] val underlying: ZSTM[Throw
   final def withFilter(f: A => Boolean): STM[F, A] = filter(f)
 
   /**
-   * See [[zio.stm.STM#zip]]
+   * See [[zio.stm.ZSTM#zip]]
    */
   final def zip[B](that: => STM[F, B]): STM[F, (A, B)] =
     (self zipWith that)((a, b) => a -> b)
 
   /**
-   * See [[zio.stm.STM#zipLeft]]
+   * See [[zio.stm.ZSTM#zipLeft]]
    */
   final def zipLeft[B](that: => STM[F, B]): STM[F, A] =
     (self zip that) map (_._1)
 
   /**
-   * See [[zio.stm.STM#zipRight]]
+   * See [[zio.stm.ZSTM#zipRight]]
    */
   final def zipRight[B](that: => STM[F, B]): STM[F, B] =
     (self zip that) map (_._2)
 
   /**
-   * See [[zio.stm.STM#zipWith]]
+   * See [[zio.stm.ZSTM#zipWith]]
    */
   final def zipWith[B, C](that: => STM[F, B])(f: (A, B) => C): STM[F, C] =
     self flatMap (a => that map (b => f(a, b)))

--- a/interop-cats/shared/src/main/scala/zio/interop/stm/TQueue.scala
+++ b/interop-cats/shared/src/main/scala/zio/interop/stm/TQueue.scala
@@ -36,7 +36,7 @@ class TQueue[F[+_], A] private (val underlying: ZTQueue[A]) extends AnyVal {
   /**
    * See [[zio.stm.TQueue#offerAll]]
    */
-  final def offerAll(as: List[A]): STM[F, Unit] = new STM(underlying.offerAll(as))
+  final def offerAll(as: Iterable[A]): STM[F, Iterable[A]] = new STM(underlying.offerAll(as))
 
   /**
    * See [[zio.stm.TQueue#poll]]
@@ -65,6 +65,6 @@ class TQueue[F[+_], A] private (val underlying: ZTQueue[A]) extends AnyVal {
 }
 
 object TQueue {
-  final def make[F[+_], A](capacity: Int): STM[F, TQueue[F, A]] =
-    new STM(ZTQueue.make[A](capacity).map(new TQueue(_)))
+  final def bounded[F[+_], A](capacity: Int): STM[F, TQueue[F, A]] =
+    new STM(ZTQueue.bounded[A](capacity).map(new TQueue(_)))
 }

--- a/interop-cats/shared/src/main/scala/zio/interop/stm/TRef.scala
+++ b/interop-cats/shared/src/main/scala/zio/interop/stm/TRef.scala
@@ -54,12 +54,12 @@ class TRef[F[+_], A] private (val underlying: ZTRef[A]) extends AnyVal {
   /**
    * See [[zio.stm.TRef#update]]
    */
-  final def update(f: A => A): STM[F, A] = new STM(underlying.update(f))
+  final def update(f: A => A): STM[F, Unit] = new STM(underlying.update(f))
 
   /**
    * See [[zio.stm.TRef#updateSome]]
    */
-  final def updateSome(f: PartialFunction[A, A]): STM[F, A] = new STM(underlying.updateSome(f))
+  final def updateSome(f: PartialFunction[A, A]): STM[F, Unit] = new STM(underlying.updateSome(f))
 }
 
 object TRef {

--- a/interop-cats/shared/src/main/scala/zio/test/CatsTestFunctions.scala
+++ b/interop-cats/shared/src/main/scala/zio/test/CatsTestFunctions.scala
@@ -27,7 +27,7 @@ trait CatsTestFunctions {
    * Checks the assertion holds for the given effectfully-computed value.
    */
   final def assertF[F[_], R, A](value: F[A], assertion: Assertion[A])(implicit F: Effect[F]): RIO[R, TestResult] =
-    assertM(fromEffect(value), assertion)
+    assertM(fromEffect(value))(assertion)
 
   /**
    * Checks the effectual test passes for "sufficient" numbers of samples from
@@ -99,36 +99,36 @@ trait CatsTestFunctions {
   final def checkSomeF[F[_], R, A](
     rv: Gen[R, A]
   )(n: Int)(test: A => F[TestResult])(implicit F: Effect[F]): RIO[R, TestResult] =
-    checkSomeM(n)(rv)(a => fromEffect(test(a)))
+    checkNM(n)(rv)(a => fromEffect(test(a)))
 
   /**
-   * A version of `checkSomeM` that accepts two random variables.
+   * A version of `checkNM` that accepts two random variables.
    */
   final def checkSomeF[F[_], R, A, B](rv1: Gen[R, A], rv2: Gen[R, B])(
     n: Int
   )(test: (A, B) => F[TestResult])(implicit F: Effect[F]): RIO[R, TestResult] =
-    checkSomeM(n)(rv1, rv2)((a, b) => fromEffect(test(a, b)))
+    checkNM(n)(rv1, rv2)((a, b) => fromEffect(test(a, b)))
 
   /**
-   * A version of `checkSomeM` that accepts three random variables.
+   * A version of `checkNM` that accepts three random variables.
    */
   final def checkSomeF[F[_], R, A, B, C](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C])(
     n: Int
   )(test: (A, B, C) => F[TestResult])(implicit F: Effect[F]): RIO[R, TestResult] =
-    checkSomeM(n)(rv1, rv2, rv3)((a, b, c) => fromEffect(test(a, b, c)))
+    checkNM(n)(rv1, rv2, rv3)((a, b, c) => fromEffect(test(a, b, c)))
 
   /**
-   * A version of `checkSomeM` that accepts four random variables.
+   * A version of `checkNM` that accepts four random variables.
    */
   final def checkSomeF[F[_], R, A, B, C, D](rv1: Gen[R, A], rv2: Gen[R, B], rv3: Gen[R, C], rv4: Gen[R, D])(
     n: Int
   )(test: (A, B, C, D) => F[TestResult])(implicit F: Effect[F]): RIO[R, TestResult] =
-    checkSomeM(n)(rv1, rv2, rv3, rv4)((a, b, c, d) => fromEffect(test(a, b, c, d)))
+    checkNM(n)(rv1, rv2, rv3, rv4)((a, b, c, d) => fromEffect(test(a, b, c, d)))
 
   /**
    * Builds a spec with a single effectful test.
    */
-  final def testF[F[_], L](label: L)(assertion: F[TestResult])(implicit F: Effect[F]): ZSpec[Any, Throwable, L, Unit] =
+  final def testF[F[_]](label: String)(assertion: F[TestResult])(implicit F: Effect[F]): ZSpec[Any, Throwable] =
     testM(label)(fromEffect(assertion))
 
   private def fromEffect[F[_], A](eff: F[A])(implicit F: Effect[F]): Task[A] =

--- a/interop-cats/shared/src/test/scala/zio/interop/GenIOInteropCats.scala
+++ b/interop-cats/shared/src/test/scala/zio/interop/GenIOInteropCats.scala
@@ -29,7 +29,7 @@ trait GenIOInteropCats {
   /**
    * Given a generator for `E`, produces a generator for `IO[E, A]` using the `IO.fail` constructor.
    */
-  def genSyncFailure[E: Arbitrary, A]: Gen[IO[E, A]] = Arbitrary.arbitrary[E].map(IO.fail[E])
+  def genSyncFailure[E: Arbitrary, A]: Gen[IO[E, A]] = Arbitrary.arbitrary[E].map(IO.failNow[E])
 
   /**
    * Given a generator for `E`, produces a generator for `IO[E, A]` using the `IO.async` constructor.

--- a/interop-cats/shared/src/test/scala/zio/interop/catzSpecBase.scala
+++ b/interop-cats/shared/src/test/scala/zio/interop/catzSpecBase.scala
@@ -9,20 +9,22 @@ import org.typelevel.discipline.Laws
 import org.typelevel.discipline.scalatest.Discipline
 import zio.clock.Clock
 import zio.console.Console
-import zio.internal.{ Executor, PlatformLive }
+import zio.internal.{ Executor, Platform }
 import zio.interop.catz.taskEffectInstance
 import zio.random.Random
 import zio.system.System
-import zio.{ Cause, DefaultRuntime, IO, Runtime, UIO, ZIO }
+import zio.{ Cause, IO, Runtime, UIO, ZIO, ZEnv }
 
 private[zio] trait catzSpecBase extends AnyFunSuite with Discipline with TestInstances with catzSpecBaseLowPriority {
 
   type Env = Clock with Console with System with Random
 
-  implicit def rts(implicit tc: TestContext): Runtime[Env] = new DefaultRuntime {
-    override val platform = PlatformLive
+  implicit def rts(implicit tc: TestContext): Runtime[Env] = new Runtime[Env] {
+    override val platform = Platform
       .fromExecutor(Executor.fromExecutionContext(Int.MaxValue)(tc))
       .withReportFailure(_ => ())
+
+    override val environment: Env = Runtime.unsafeFromLayer(ZEnv.live, platform).environment
   }
 
   implicit def zioEqCause[E]: Eq[Cause[E]] = zioEqCause0.asInstanceOf[Eq[Cause[E]]]

--- a/interop-cats/shared/src/test/scala/zio/interop/catzSpecBase.scala
+++ b/interop-cats/shared/src/test/scala/zio/interop/catzSpecBase.scala
@@ -13,7 +13,7 @@ import zio.internal.{ Executor, Platform }
 import zio.interop.catz.taskEffectInstance
 import zio.random.Random
 import zio.system.System
-import zio.{ Cause, IO, Runtime, UIO, ZIO, ZEnv }
+import zio.{ Cause, IO, Runtime, UIO, ZEnv, ZIO }
 
 private[zio] trait catzSpecBase extends AnyFunSuite with Discipline with TestInstances with catzSpecBaseLowPriority {
 

--- a/interop-cats/shared/src/test/scala/zio/stream/interop/GenStreamInteropCats.scala
+++ b/interop-cats/shared/src/test/scala/zio/stream/interop/GenStreamInteropCats.scala
@@ -8,12 +8,12 @@ trait GenStreamInteropCats {
   /**
    * Given a generator for `List[A]`, produces a generator for `Stream[E, A]` using the `Stream.fromIterable` constructor.
    */
-  def genSuccess[E, A: Arbitrary]: Gen[Stream[E, A]] = Arbitrary.arbitrary[A].map(Stream.succeed)
+  def genSuccess[E, A: Arbitrary]: Gen[Stream[E, A]] = Arbitrary.arbitrary[A].map(Stream.succeedNow)
 
   /**
    * Given a generator for `E`, produces a generator for `Stream[E, A]` using the `Stream.fail` constructor.
    */
-  def genFailure[E: Arbitrary, A]: Gen[Stream[E, A]] = Arbitrary.arbitrary[E].map(Stream.fail[E])
+  def genFailure[E: Arbitrary, A]: Gen[Stream[E, A]] = Arbitrary.arbitrary[E].map(Stream.failNow[E])
 
   /**
    * Randomly uses either `genSuccess` or `genFailure` with equal probability.

--- a/interop-cats/shared/src/test/scala/zio/test/interop/TestSpec.scala
+++ b/interop-cats/shared/src/test/scala/zio/test/interop/TestSpec.scala
@@ -7,20 +7,20 @@ import zio.test.Assertion._
 import zio.test.TestAspect._
 import zio.test._
 
-object TestSpec
-    extends DefaultRunnableSpec(
-      suite("TestSpec")(
-        testF("arbitrary effects can be tested") {
+object TestSpec extends DefaultRunnableSpec {
+  val spec =
+    suite("TestSpec")(
+      testF("arbitrary effects can be tested") {
+        for {
+          result <- IO("Hello from Cats!")
+        } yield assert(result)(equalTo("Hello from Cats!"))
+      },
+      timeout(0.milliseconds) {
+        testF("ZIO interruption is tied to F interruption") {
           for {
-            result <- IO("Hello from Cats!")
-          } yield assert(result, equalTo("Hello from Cats!"))
-        },
-        timeout(0.milliseconds) {
-          testF("ZIO interruption is tied to F interruption") {
-            for {
-              _ <- IO.never
-            } yield assert((), anything)
-          }
-        } @@ failure
-      )
+            _ <- IO.never
+          } yield assert(())(anything)
+        }
+      } @@ failure
     )
+}

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -7,6 +7,9 @@ import sbtbuildinfo._
 import BuildInfoKeys._
 
 object BuildHelper {
+
+  val zioVersion = "1.0.0-RC17+385-240a27d8-SNAPSHOT"
+
   val testDeps        = Seq("org.scalacheck"  %% "scalacheck"   % "1.14.3" % "test")
   val compileOnlyDeps = Seq("com.github.ghik" %% "silencer-lib" % "1.4.2"  % "provided")
 


### PR DESCRIPTION
I'm experimenting with new DI encoding (Has & ZLayer) from the latest ZIO and I needed to update interop-cats to play with http4s/doobie.
This ofcourse will need to be updated when the next version lands (be it `1.0.0` or `1.0.0-RC18`).