### PR TITLE
Make both sides of race interruptible, generate interruptible races (and fix failing laws that way)

### DIFF
--- a/.sbtopts
+++ b/.sbtopts
@@ -1,5 +1,5 @@
 -J-Xss5M
 -J-XX:ReservedCodeCacheSize=256m
--J-Xmx4G
+-J-Xmx5G
 -J-XX:MaxMetaspaceSize=3G
 -J-XX:MaxInlineLevel=18

--- a/interop-cats/shared/src/main/scala/zio/interop/cats.scala
+++ b/interop-cats/shared/src/main/scala/zio/interop/cats.scala
@@ -331,13 +331,13 @@ private class CatsParApplicative[R, E] extends CommutativeApplicative[ParIO[R, E
     Par(ZIO.succeed(x))
 
   final override def map2[A, B, Z](fa: ParIO[R, E, A], fb: ParIO[R, E, B])(f: (A, B) => Z): ParIO[R, E, Z] =
-    Par(Par.unwrap(fa).zipWithPar(Par.unwrap(fb))(f))
+    Par(Par.unwrap(fa).interruptible.zipWithPar(Par.unwrap(fb).interruptible)(f))
 
   final override def ap[A, B](ff: ParIO[R, E, A => B])(fa: ParIO[R, E, A]): ParIO[R, E, B] =
-    Par(Par.unwrap(ff).zipWithPar(Par.unwrap(fa))(_(_)))
+    Par(Par.unwrap(ff).interruptible.zipWithPar(Par.unwrap(fa).interruptible)(_(_)))
 
   final override def product[A, B](fa: ParIO[R, E, A], fb: ParIO[R, E, B]): ParIO[R, E, (A, B)] =
-    Par(Par.unwrap(fa).zipPar(Par.unwrap(fb)))
+    Par(Par.unwrap(fa).interruptible.zipPar(Par.unwrap(fb).interruptible))
 
   final override def map[A, B](fa: ParIO[R, E, A])(f: A => B): ParIO[R, E, B] =
     Par(Par.unwrap(fa).map(f))

--- a/interop-cats/shared/src/main/scala/zio/interop/cats.scala
+++ b/interop-cats/shared/src/main/scala/zio/interop/cats.scala
@@ -281,7 +281,12 @@ private class CatsMonadError[R, E] extends MonadError[ZIO[R, E, *], E] with Stac
 
 /** lossy, throws away errors using the "first success" interpretation of SemigroupK */
 private class CatsSemigroupKLossy[R, E] extends SemigroupK[ZIO[R, E, *]] {
-  override final def combineK[A](a: ZIO[R, E, A], b: ZIO[R, E, A]): ZIO[R, E, A] = a.orElse(b)
+  override final def combineK[A](a: ZIO[R, E, A], b: ZIO[R, E, A]): ZIO[R, E, A] =
+    a.catchAll { e1 =>
+      b.catchAll { _ =>
+        ZIO.failNow(e1)
+      }
+    }
 }
 
 private class CatsSemigroupK[R, E: Semigroup] extends SemigroupK[ZIO[R, E, *]] {

--- a/interop-cats/shared/src/test/scala/zio/interop/GenIOInteropCats.scala
+++ b/interop-cats/shared/src/test/scala/zio/interop/GenIOInteropCats.scala
@@ -1,6 +1,6 @@
 package zio.interop
 
-import zio._
+import zio.{ IO, Promise, ZIO, ZManaged }
 import org.scalacheck._
 
 /**
@@ -114,7 +114,7 @@ trait GenIOInteropCats {
     Gen.const(io.flatMap(a => IO.succeed(a)))
 
   private def genOfRace[E, A](io: IO[E, A]): Gen[IO[E, A]] =
-    Gen.const(io.race(IO.never))
+    Gen.const(io.interruptible.race(ZIO.never.interruptible))
 
   private def genOfParallel[E, A](io: IO[E, A])(gen: Gen[IO[E, A]]): Gen[IO[E, A]] =
     gen.map { parIo =>

--- a/interop-cats/shared/src/test/scala/zio/interop/GenIOInteropCats.scala
+++ b/interop-cats/shared/src/test/scala/zio/interop/GenIOInteropCats.scala
@@ -1,7 +1,7 @@
 package zio.interop
 
-import zio.{ IO, Promise, ZIO, ZManaged }
 import org.scalacheck._
+import zio.{ IO, ZIO }
 
 /**
  * Temporary fork of zio.GenIO that overrides `genParallel` with ZManaged-based code
@@ -118,13 +118,7 @@ trait GenIOInteropCats {
 
   private def genOfParallel[E, A](io: IO[E, A])(gen: Gen[IO[E, A]]): Gen[IO[E, A]] =
     gen.map { parIo =>
-//      io.zipPar(parIo).map(_._1)
-      Promise.make[Nothing, Unit].flatMap { p =>
-        ZManaged
-          .fromEffect(parIo *> p.succeed(()))
-          .fork
-          .use_(p.await *> io)
-      }
+      io.interruptible.zipPar(parIo.interruptible).map(_._1)
     }
 
 }

--- a/interop-cats/shared/src/test/scala/zio/interop/GenIOInteropCats.scala
+++ b/interop-cats/shared/src/test/scala/zio/interop/GenIOInteropCats.scala
@@ -1,7 +1,7 @@
 package zio.interop
 
 import org.scalacheck._
-import zio.{ IO, ZIO }
+import zio.{ IO, Promise, ZIO, ZManaged }
 
 /**
  * Temporary fork of zio.GenIO that overrides `genParallel` with ZManaged-based code
@@ -118,7 +118,14 @@ trait GenIOInteropCats {
 
   private def genOfParallel[E, A](io: IO[E, A])(gen: Gen[IO[E, A]]): Gen[IO[E, A]] =
     gen.map { parIo =>
-      io.interruptible.zipPar(parIo.interruptible).map(_._1)
+      // this should work, but generates more random failures on CI
+//      io.interruptible.zipPar(parIo.interruptible).map(_._1)
+      Promise.make[Nothing, Unit].flatMap { p =>
+        ZManaged
+          .fromEffect(parIo *> p.succeed(()))
+          .fork
+          .use_(p.await *> io)
+      }
     }
 
 }

--- a/interop-cats/shared/src/test/scala/zio/interop/catzSpec.scala
+++ b/interop-cats/shared/src/test/scala/zio/interop/catzSpec.scala
@@ -18,10 +18,11 @@ class catzSpec extends catzSpecZIOBase {
   def genUIO[A: Arbitrary]: Gen[UIO[A]] =
     Gen.oneOf(genSuccess[Nothing, A], genIdentityTrans(genSuccess[Nothing, A]))
 
-  checkAllAsync(
-    "ConcurrentEffect[Task]",
-    implicit tc => ConcurrentEffectTestsOverrides[Task].concurrentEffect[Int, Int, Int]
-  )
+  for (i <- 1 to 10)
+    checkAllAsync(
+      s"ConcurrentEffect[Task] $i",
+      implicit tc => ConcurrentEffectTestsOverrides[Task].concurrentEffect[Int, Int, Int]
+    )
   checkAllAsync("Effect[Task]", implicit tc => EffectTestsOverrides[Task].effect[Int, Int, Int])
   checkAllAsync("Concurrent[Task]", implicit tc => ConcurrentTestsOverrides[Task].concurrent[Int, Int, Int])
   checkAllAsync("MonadError[IO[Int, *]]", implicit tc => MonadErrorTests[IO[Int, *], Int].monadError[Int, Int, Int])

--- a/interop-cats/shared/src/test/scala/zio/interop/catzSpec.scala
+++ b/interop-cats/shared/src/test/scala/zio/interop/catzSpec.scala
@@ -1,18 +1,17 @@
 package zio.interop
 
-import cats.{ Monad, SemigroupK }
 import cats.effect.concurrent.Deferred
 import cats.effect.laws.discipline.arbitrary._
 import cats.effect.laws.discipline.{ ConcurrentEffectTests, ConcurrentTests, EffectTests, SyncTests }
-import cats.effect.laws.{ AsyncLaws, BracketLaws, ConcurrentEffectLaws, ConcurrentLaws, EffectLaws }
-import cats.effect.{ Async, Bracket, Concurrent, ConcurrentEffect, ContextShift, Effect }
+import cats.effect.laws._
+import cats.effect.{ Concurrent, ConcurrentEffect, ContextShift, Effect }
 import cats.implicits._
 import cats.laws._
 import cats.laws.discipline._
+import cats.{ Monad, SemigroupK }
 import org.scalacheck.{ Arbitrary, Cogen, Gen }
 import zio.interop.catz._
 import zio.{ IO, _ }
-import scala.concurrent.Promise
 
 class catzSpec extends catzSpecZIOBase {
 
@@ -131,47 +130,13 @@ trait AsyncLawsOverrides[F[_]] extends AsyncLaws[F] {
 
 }
 
-trait BracketLawsOverrides[F[_], E] extends BracketLaws[F, E] {
+trait BracketLawsOverrides[F[_], E] extends BracketLaws[F, E] {}
 
-  implicit def F: Bracket[F, E]
+trait ConcurrentLawsOverrides[F[_]] extends ConcurrentLaws[F] {}
 
-  // TODO: disabled failing test -> fix underlying issue
-  override def bracketCaseWithPureUnitIsEqvMap[A, B](fa: F[A], f: A => B) =
-    F.map(fa)(f) <-> F.map(fa)(f)
-}
+trait SemigroupKLawsOverrides[F[_]] extends SemigroupKLaws[F] {}
 
-trait ConcurrentLawsOverrides[F[_]] extends ConcurrentLaws[F] {
-
-  // TODO: disabled failing test -> fix underlying issue
-  override def uncancelableMirrorsSource[A](fa: F[A]) =
-    fa <-> fa
-}
-
-trait SemigroupKLawsOverrides[F[_]] extends SemigroupKLaws[F] {
-
-  // TODO: disabled failing test -> fix underlying issue
-  override def semigroupKAssociative[A](a: F[A], b: F[A], c: F[A]): IsEq[F[A]] =
-    a <-> a
-}
-
-trait ConcurrentEffectLawsOverrides[F[_]] extends ConcurrentEffectLaws[F] {
-  import cats.effect.IO
-
-  override def runCancelableIsSynchronous[A]: IsEq[F[Unit]] = {
-    val lh = Deferred.uncancelable[F, Unit].flatMap { latch =>
-      val spawned = Promise[Unit]()
-      // Never ending task
-      val ff = F.cancelable[A](_ => { spawned.success(()); latch.complete(()) })
-      // Execute, then cancel
-      val token = F.delay(F.runCancelable(ff)(_ => IO.unit).unsafeRunSync()).flatMap { canceler =>
-        Async.fromFuture(F.pure(spawned.future)) >> canceler
-      }
-      F.liftIO(F.runAsync(token)(_ => IO.unit).toIO) *> latch.get
-    }
-    lh <-> F.unit
-  }
-
-}
+trait ConcurrentEffectLawsOverrides[F[_]] extends ConcurrentEffectLaws[F] {}
 
 object SemigroupKTestsOverrides {
 

--- a/interop-cats/shared/src/test/scala/zio/interop/catzSpec.scala
+++ b/interop-cats/shared/src/test/scala/zio/interop/catzSpec.scala
@@ -18,11 +18,10 @@ class catzSpec extends catzSpecZIOBase {
   def genUIO[A: Arbitrary]: Gen[UIO[A]] =
     Gen.oneOf(genSuccess[Nothing, A], genIdentityTrans(genSuccess[Nothing, A]))
 
-  for (i <- 1 to 10)
-    checkAllAsync(
-      s"ConcurrentEffect[Task] $i",
-      implicit tc => ConcurrentEffectTestsOverrides[Task].concurrentEffect[Int, Int, Int]
-    )
+  checkAllAsync(
+    "ConcurrentEffect[Task]",
+    implicit tc => ConcurrentEffectTestsOverrides[Task].concurrentEffect[Int, Int, Int]
+  )
   checkAllAsync("Effect[Task]", implicit tc => EffectTestsOverrides[Task].effect[Int, Int, Int])
   checkAllAsync("Concurrent[Task]", implicit tc => ConcurrentTestsOverrides[Task].concurrent[Int, Int, Int])
   checkAllAsync("MonadError[IO[Int, *]]", implicit tc => MonadErrorTests[IO[Int, *], Int].monadError[Int, Int, Int])

--- a/interop-cats/shared/src/test/scala/zio/interop/catzSpecBase.scala
+++ b/interop-cats/shared/src/test/scala/zio/interop/catzSpecBase.scala
@@ -13,7 +13,7 @@ import zio.internal.{ Executor, Platform, Tracing }
 import zio.interop.catz.taskEffectInstance
 import zio.random.Random
 import zio.system.System
-import zio.{ Cause, IO, Runtime, UIO, ZIO }
+import zio.{ Cause, IO, Runtime, Task, UIO, ZIO }
 
 private[zio] trait catzSpecBase extends AnyFunSuite with Discipline with TestInstances with catzSpecBaseLowPriority {
 
@@ -27,10 +27,12 @@ private[zio] trait catzSpecBase extends AnyFunSuite with Discipline with TestIns
       .withReportFailure(_ => ())
   )
 
-  implicit def zioEqCause[E]: Eq[Cause[E]] = zioEqCause0.asInstanceOf[Eq[Cause[E]]]
-  private val zioEqCause0: Eq[Cause[Any]]  = Eq.by[Cause[Any], Option[Any]](_.failureOption)(Eq.fromUniversalEquals)
+  implicit val zioEqCauseNothing: Eq[Cause[Nothing]] = Eq.fromUniversalEquals
 
   implicit def zioEqIO[E: Eq, A: Eq](implicit rts: Runtime[Any], tc: TestContext): Eq[IO[E, A]] =
+    Eq.by(_.either)
+
+  implicit def zioEqTask[A: Eq](implicit rts: Runtime[Any], tc: TestContext): Eq[Task[A]] =
     Eq.by(_.either)
 
   implicit def zioEqUIO[A: Eq](implicit rts: Runtime[Any], tc: TestContext): Eq[UIO[A]] =
@@ -43,8 +45,8 @@ private[zio] trait catzSpecBase extends AnyFunSuite with Discipline with TestIns
 
 private[interop] sealed trait catzSpecBaseLowPriority { this: catzSpecBase =>
 
-  implicit def zioEq[R: Arbitrary, E, A: Eq](implicit rts: Runtime[Any], tc: TestContext): Eq[ZIO[R, E, A]] = {
-    def run(r: R, zio: ZIO[R, E, A]) = taskEffectInstance.toIO(zio.provide(r).sandbox.either)
+  implicit def zioEq[R: Arbitrary, E: Eq, A: Eq](implicit rts: Runtime[Any], tc: TestContext): Eq[ZIO[R, E, A]] = {
+    def run(r: R, zio: ZIO[R, E, A]) = taskEffectInstance.toIO(zio.provide(r).either)
     Eq.instance((io1, io2) => Arbitrary.arbitrary[R].sample.fold(false)(r => catsSyntaxEq(run(r, io1)) eqv run(r, io2)))
   }
 

--- a/interop-cats/shared/src/test/scala/zio/interop/catzSpecZIOBase.scala
+++ b/interop-cats/shared/src/test/scala/zio/interop/catzSpecZIOBase.scala
@@ -4,14 +4,14 @@ import cats.Eq
 import cats.effect.laws.util.TestContext
 import cats.implicits._
 import org.scalacheck.{ Arbitrary, Cogen, Gen }
-import zio.{ IO, ZIO, ZManaged }
+import zio.{ IO, Runtime, ZIO, ZManaged }
 
 private[interop] trait catzSpecZIOBase extends catzSpecBase with GenIOInteropCats {
 
-  implicit def zioEqParIO[E: Eq, A: Eq](implicit tc: TestContext): Eq[ParIO[Any, E, A]] =
+  implicit def zioEqParIO[E: Eq, A: Eq](implicit rts: Runtime[Any], tc: TestContext): Eq[ParIO[Any, E, A]] =
     Eq.by(Par.unwrap(_))
 
-  implicit def zioEqZManaged[E: Eq, A: Eq](implicit tc: TestContext): Eq[ZManaged[Any, E, A]] =
+  implicit def zioEqZManaged[E: Eq, A: Eq](implicit rts: Runtime[Any], tc: TestContext): Eq[ZManaged[Any, E, A]] =
     Eq.by(_.reserve.flatMap(_.acquire).either)
 
   implicit def zioArbitrary[R: Cogen, E: Arbitrary: Cogen, A: Arbitrary: Cogen]: Arbitrary[ZIO[R, E, A]] =

--- a/interop-cats/shared/src/test/scala/zio/stream/interop/catzSpecZStreamBase.scala
+++ b/interop-cats/shared/src/test/scala/zio/stream/interop/catzSpecZStreamBase.scala
@@ -35,8 +35,8 @@ private[interop] trait catzSpecZStreamBase
 
 private[interop] trait catzSpecZStreamBaseLowPriority { self: catzSpecZStreamBase =>
 
-  implicit def zstreamEq[R: Arbitrary, E, A: Eq](implicit tc: TestContext): Eq[ZStream[R, E, A]] = {
-    def run(r: R, zstream: ZStream[R, E, A]) = taskEffectInstance.toIO(zstream.runCollect.provide(r).sandbox.either)
+  implicit def zstreamEq[R: Arbitrary, E: Eq, A: Eq](implicit tc: TestContext): Eq[ZStream[R, E, A]] = {
+    def run(r: R, zstream: ZStream[R, E, A]) = taskEffectInstance.toIO(zstream.runCollect.provide(r).either)
     Eq.instance(
       (stream1, stream2) =>
         Arbitrary.arbitrary[R].sample.fold(false)(r => catsSyntaxEq(run(r, stream1)) eqv run(r, stream2))


### PR DESCRIPTION
The tests were failing because we were generating uninterruptible races under `uncancelable` and bracket, which didn't make sense for `eqIO` - 

```scala
-    Gen.const(io.race(IO.never))
+    Gen.const(io.interruptible.race(ZIO.never.interruptible))
```

the cats test `uncancelableMirrorsSource` identified the issue correctly `uncancelable(race) != race` because `race` after RC18 inherits interruption status and becomes completely uncancelable too.

inspired by https://github.com/zio/zio/issues/3065

> **Safer race**
> Race no longer forces either side to be interruptible. Users may have to perform left.interruptible.race(right.interruptible) to acquire the old behavior (which punched holes in uninterruptible regions); or possibly, left.disconnect.race(right.disconnect) (if they want the effects to be keep running when interrupted, but in the background).
