### PR TITLE
Add NonEmptyChunk reducible instance

### DIFF
--- a/interop-cats/shared/src/main/scala/zio/interop/cats.scala
+++ b/interop-cats/shared/src/main/scala/zio/interop/cats.scala
@@ -122,7 +122,7 @@ abstract class CatsInstances extends CatsInstances1 {
     contravariantInstance0.asInstanceOf[Contravariant[ZIO[*, E, A]]]
 
   implicit final val nonEmptyChunkReducibleInstance: Reducible[NonEmptyChunk] = new NonEmptyChunkReducible
-  implicit final def nonEmptyChunkEqInstance[A]: Eq[NonEmptyChunk[A]]          = new NonEmptyChunkEq[A]
+  implicit final def nonEmptyChunkEqInstance[A]: Eq[NonEmptyChunk[A]]         = new NonEmptyChunkEq[A]
 
   private[this] val bifunctorInstance0: Bifunctor[ZIO[Any, *, *]]           = new CatsBifunctor
   private[this] val zioArrowInstance0: ArrowChoice[ZIO[*, Any, *]]          = new CatsArrow

--- a/interop-cats/shared/src/main/scala/zio/interop/cats.scala
+++ b/interop-cats/shared/src/main/scala/zio/interop/cats.scala
@@ -122,7 +122,7 @@ abstract class CatsInstances extends CatsInstances1 {
     contravariantInstance0.asInstanceOf[Contravariant[ZIO[*, E, A]]]
 
   implicit final val nonEmptyChunkReducibleInstance: Reducible[NonEmptyChunk] = new NonEmptyChunkReducible
-  implicit final val nonEmptyChunkEqInstance: Eq[NonEmptyChunk[Int]]          = new NonEmptyChunkEq
+  implicit final def nonEmptyChunkEqInstance[A]: Eq[NonEmptyChunk[A]]          = new NonEmptyChunkEq[A]
 
   private[this] val bifunctorInstance0: Bifunctor[ZIO[Any, *, *]]           = new CatsBifunctor
   private[this] val zioArrowInstance0: ArrowChoice[ZIO[*, Any, *]]          = new CatsArrow

--- a/interop-cats/shared/src/main/scala/zio/interop/cats.scala
+++ b/interop-cats/shared/src/main/scala/zio/interop/cats.scala
@@ -122,7 +122,7 @@ abstract class CatsInstances extends CatsInstances1 {
     contravariantInstance0.asInstanceOf[Contravariant[ZIO[*, E, A]]]
 
   implicit final val nonEmptyChunkReducibleInstance: Reducible[NonEmptyChunk] = new NonEmptyChunkReducible
-  implicit final def nonEmptyChunkEqInstance[A]: Eq[NonEmptyChunk[A]]         = new NonEmptyChunkEq[A]
+  implicit final def nonEmptyChunkEqInstance[A: Eq]: Eq[NonEmptyChunk[A]]     = new NonEmptyChunkEq[A]
 
   private[this] val bifunctorInstance0: Bifunctor[ZIO[Any, *, *]]           = new CatsBifunctor
   private[this] val zioArrowInstance0: ArrowChoice[ZIO[*, Any, *]]          = new CatsArrow
@@ -417,10 +417,10 @@ final private class NonEmptyChunkReducible extends Reducible[NonEmptyChunk] {
 
 }
 
-final private class NonEmptyChunkEq[A] extends Eq[NonEmptyChunk[A]] {
+final private class NonEmptyChunkEq[A: Eq] extends Eq[NonEmptyChunk[A]] {
 
   override def eqv(x: NonEmptyChunk[A], y: NonEmptyChunk[A]): Boolean =
     if (x.length != y.length) false
-    else x.zip(y).forall { case (a, b) => a == b }
+    else x.zip(y).forall { case (a, b) => Eq[A].eqv(a, b) }
 
 }

--- a/interop-cats/shared/src/test/scala/zio/interop/catzSpec.scala
+++ b/interop-cats/shared/src/test/scala/zio/interop/catzSpec.scala
@@ -44,8 +44,7 @@ class catzSpec extends catzSpecZIOBase {
 
   // NonEmptyChunk Tests
   checkAll(
-    "Reducible[NonEmptyChunk]",
-    {
+    "Reducible[NonEmptyChunk]", {
       val intGen: Gen[Int] = Gen.chooseNum(Int.MinValue, Int.MaxValue)
       def nonEmptyListGen[A](gen: => Gen[A]): Gen[NonEmptyList[A]] =
         for {

--- a/interop-cats/shared/src/test/scala/zio/interop/catzSpec.scala
+++ b/interop-cats/shared/src/test/scala/zio/interop/catzSpec.scala
@@ -45,7 +45,7 @@ class catzSpec extends catzSpecZIOBase {
   // NonEmptyChunk Tests
   checkAll(
     "Reducible[NonEmptyChunk]", {
-      val intGen: Gen[Int] = Gen.chooseNum(Int.MinValue, Int.MaxValue)
+      val byteGen: Gen[Byte] = Gen.chooseNum(Byte.MinValue, Byte.MaxValue)
       def nonEmptyListGen[A](gen: => Gen[A]): Gen[NonEmptyList[A]] =
         for {
           head <- gen
@@ -55,11 +55,11 @@ class catzSpec extends catzSpecZIOBase {
       def nonEmptyChunk[A](gen: => Gen[A]): Gen[NonEmptyChunk[A]] =
         nonEmptyListGen(gen).map(nel => NonEmptyChunk.fromCons(::(nel.head, nel.tail)))
 
-      implicit val arbitratyNonEmptyChunk: Arbitrary[NonEmptyChunk[Int]] = Arbitrary(nonEmptyChunk(intGen))
-      implicit val arbitratyNonEmptyChunkOpt: Arbitrary[NonEmptyChunk[Option[Int]]] =
-        Arbitrary(nonEmptyChunk(Gen.option(intGen)))
+      implicit val arbitratyNonEmptyChunk: Arbitrary[NonEmptyChunk[Byte]] = Arbitrary(nonEmptyChunk(byteGen))
+      implicit val arbitratyNonEmptyChunkOpt: Arbitrary[NonEmptyChunk[Option[Byte]]] =
+        Arbitrary(nonEmptyChunk(Gen.option(byteGen)))
 
-      ReducibleTests[NonEmptyChunk].reducible[Option, Int, Int]
+      ReducibleTests[NonEmptyChunk].reducible[Option, Byte, Byte]
     }
   )
 


### PR DESCRIPTION
@adamgfraser, could you give me some feedback on wether this is acceptable?

I was told `Chunk#foldRight` isn't lazy enough, so implementing `foldRight` and `reduceRightTo` in terms of it would not be optimal (I don't know if this is critical though).

Regarding `reduceRightTo`, I couldn't find a way to pattern match on the `NonEmptyChunk` so as to not use `last` (which is unsafe) so I followed the pragmatical approach with the `if / else` expression.

I'd be happy work some more on this if my solution is not adequate.