### PR TITLE
Fix the race combinators

### DIFF
--- a/interop-cats/shared/src/main/scala/zio/interop/cats.scala
+++ b/interop-cats/shared/src/main/scala/zio/interop/cats.scala
@@ -227,12 +227,12 @@ private class CatsConcurrent[R] extends CatsMonadError[R, Throwable] with Concur
       Left(token.orDie)
     }
 
-  override final def race[A, B](fa: RIO[R, A], fb: RIO[R, B]): RIO[R, Either[A, B]] =
-    (fa.map(Left(_)).interruptible raceWith fb.map(Right(_)).interruptible)(
-      { case (l, f) => l.fold(f.interrupt *> ZIO.halt(_), ZIO.succeedNow) },
-      { case (r, f) => r.fold(f.interrupt *> ZIO.halt(_), ZIO.succeedNow) },
-      Some(ZScope.global)
-    )
+  override final def race[A, B](fa: RIO[R, A], fb: RIO[R, B]): RIO[R, Either[A, B]] = {
+    def run[C](fc: RIO[R, C]): ZIO[R, Throwable, C] =
+      fc.interruptible.overrideForkScope(ZScope.global)
+
+    run(fa.map(Left(_))) raceFirst run(fb.map(Right(_)))
+  }
 
   override final def start[A](fa: RIO[R, A]): RIO[R, effect.Fiber[RIO[R, *], A]] =
     fa.interruptible.forkDaemon.map(toFiber)
@@ -240,12 +240,15 @@ private class CatsConcurrent[R] extends CatsMonadError[R, Throwable] with Concur
   override final def racePair[A, B](
     fa: RIO[R, A],
     fb: RIO[R, B]
-  ): RIO[R, Either[(A, effect.Fiber[RIO[R, *], B]), (effect.Fiber[RIO[R, *], A], B)]] =
-    (fa.interruptible raceWith fb.interruptible)(
+  ): RIO[R, Either[(A, effect.Fiber[RIO[R, *], B]), (effect.Fiber[RIO[R, *], A], B)]] = {
+    def run[C](fc: RIO[R, C]): ZIO[R, Throwable, C] =
+      fc.interruptible.overrideForkScope(ZScope.global)
+
+    (run(fa) raceWith run(fb))(
       { case (l, f) => l.fold(f.interrupt *> ZIO.halt(_), ZIO.succeedNow).map(lv => Left((lv, toFiber(f)))) },
-      { case (r, f) => r.fold(f.interrupt *> ZIO.halt(_), ZIO.succeedNow).map(rv => Right((toFiber(f), rv))) },
-      Some(ZScope.global)
+      { case (r, f) => r.fold(f.interrupt *> ZIO.halt(_), ZIO.succeedNow).map(rv => Right((toFiber(f), rv))) }
     )
+  }
 
   override final def never[A]: RIO[R, A] =
     ZIO.never


### PR DESCRIPTION
Related to https://github.com/zio/zio/issues/3926 and https://github.com/zio/zio/issues/3949

Doesn't hang anymore with https://github.com/sebver/zio-http4s-scope-issue 

Also Benchmarking with:

```
ab -n 1000 -c 25 http://localhost:8080/status
This is ApacheBench, Version 2.3 <$Revision: 1843412 $>
Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/
Licensed to The Apache Software Foundation, http://www.apache.org/

Benchmarking localhost (be patient)
Completed 100 requests
Completed 200 requests
Completed 300 requests
Completed 400 requests
Completed 500 requests
Completed 600 requests
Completed 700 requests
Completed 800 requests
Completed 900 requests
Completed 1000 requests
Finished 1000 requests


Server Software:
Server Hostname:        localhost
Server Port:            8080

Document Path:          /status
Document Length:        5 bytes

Concurrency Level:      25
Time taken for tests:   1.810 seconds
Complete requests:      1000
Failed requests:        0
Total transferred:      121000 bytes
HTML transferred:       5000 bytes
Requests per second:    552.61 [#/sec] (mean)
Time per request:       45.240 [ms] (mean)
Time per request:       1.810 [ms] (mean, across all concurrent requests)
Transfer rate:          65.30 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.2      0       6
Processing:     8   44  56.2     34     410
Waiting:        6   32  47.6     24     395
Total:          8   45  56.2     34     411

Percentage of the requests served within a certain time (ms)
  50%     34
  66%     38
  75%     41
  80%     44
  90%     52
  95%     68
  98%    372
  99%    388
 100%    411 (longest request)
```
