### PR TITLE
Fix nested race issue

### DIFF
--- a/interop-cats/shared/src/main/scala/zio/interop/cats.scala
+++ b/interop-cats/shared/src/main/scala/zio/interop/cats.scala
@@ -227,13 +227,6 @@ private class CatsConcurrent[R] extends CatsMonadError[R, Throwable] with Concur
       Left(token.orDie)
     }
 
-  override final def race[A, B](fa: RIO[R, A], fb: RIO[R, B]): RIO[R, Either[A, B]] = {
-    def run[C](fc: RIO[R, C]): ZIO[R, Throwable, C] =
-      fc.interruptible.overrideForkScope(ZScope.global)
-
-    run(fa.map(Left(_))) raceFirst run(fb.map(Right(_)))
-  }
-
   override final def start[A](fa: RIO[R, A]): RIO[R, effect.Fiber[RIO[R, *], A]] =
     fa.interruptible.forkDaemon.map(toFiber)
 
@@ -247,7 +240,7 @@ private class CatsConcurrent[R] extends CatsMonadError[R, Throwable] with Concur
     (run(fa) raceWith run(fb))(
       { case (l, f) => l.fold(f.interrupt *> ZIO.halt(_), ZIO.succeedNow).map(lv => Left((lv, toFiber(f)))) },
       { case (r, f) => r.fold(f.interrupt *> ZIO.halt(_), ZIO.succeedNow).map(rv => Right((toFiber(f), rv))) }
-    )
+    ).resetForkScope
   }
 
   override final def never[A]: RIO[R, A] =


### PR DESCRIPTION
Fixes https://github.com/zio/zio/issues/4024

In the last release we added `overrideForkScope(ZScope.global)` to make sure anything forked by a side of the race would be global. The memory leak happens when there is a nested race, because the forks internal to race should not be global. 
By calling `resetForkScope` we ensure those forks are "normal" and only the ones inside left and right are global.

It shows no more leak with the reproducer, and the http4s scope issue doesn't happen either.

I also removed `race` because cats-effect already has an implementation for it using `racePair`.

cc @Fristi @sebver