### PR TITLE
Expose R parameter for ioTimer

### DIFF
--- a/interop-cats/shared/src/main/scala/zio/interop/cats.scala
+++ b/interop-cats/shared/src/main/scala/zio/interop/cats.scala
@@ -46,7 +46,7 @@ abstract class CatsEffectPlatform
   }
 
   object implicits {
-    implicit final def ioTimer[E]: effect.Timer[IO[E, *]] = ioTimer0.asInstanceOf[effect.Timer[IO[E, *]]]
+    implicit final def ioTimer[R, E]: effect.Timer[ZIO[R, E, *]] = ioTimer0.asInstanceOf[effect.Timer[ZIO[R, E, *]]]
 
     private[this] val ioTimer0: effect.Timer[IO[Any, *]] =
       zioClock.toTimer

--- a/interop-cats/shared/src/main/scala/zio/interop/cats.scala
+++ b/interop-cats/shared/src/main/scala/zio/interop/cats.scala
@@ -48,7 +48,7 @@ abstract class CatsEffectPlatform
   object implicits {
     implicit final def ioTimer[R, E]: effect.Timer[ZIO[R, E, *]] = ioTimer0.asInstanceOf[effect.Timer[ZIO[R, E, *]]]
 
-    private[this] val ioTimer0: effect.Timer[IO[Any, *]] =
+    private[this] val ioTimer0: effect.Timer[UIO] =
       zioClock.toTimer
   }
 


### PR DESCRIPTION
I don't know if we care about maintaining backwards compatibility for the `ioTimer` function, I can amend this PR to remove it, but I'm currently having to `asInstanceOf` in my own code because `Timer` is invariant