### PR TITLE
Fix: runAsync

### DIFF
--- a/interop-cats/shared/src/main/scala/zio/interop/cats.scala
+++ b/interop-cats/shared/src/main/scala/zio/interop/cats.scala
@@ -173,8 +173,9 @@ private class CatsConcurrentEffect[R](rts: Runtime[R])
     cb: Either[Throwable, A] => effect.IO[Unit]
   ): effect.SyncIO[Unit] =
     effect.SyncIO {
-      rts.unsafeRunAsync(fa.run) { exit =>
-        cb(exit.flatMap(identity).toEither).unsafeRunAsync(_ => ())
+      rts.unsafeRunSync(fa) match {
+        case Exit.Success(value) => cb(Right(value)).unsafeRunSync()
+        case Exit.Failure(cause) => cb(Left(cause.squash)).unsafeRunSync()
       }
     }
 


### PR DESCRIPTION
Locally it seems to resolve #313, bit confused here. The SyncIO seems values returned seem to use Async variants, shouldn't this be the sync variants as SyncIO implies?