### PR TITLE
Implement support for Scala 3 and 2.13.6 (Cats Effect 3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
       matrix:
         java: ['adopt@1.8', 'adopt@1.11']
-        scala: ['2.12.13', '2.13.5', '3.0.0-RC3']
+        scala: ['2.12.13', '2.13.6', '3.0.0']
         platform: ['JVM', 'JS']
     steps:
       - name: Checkout current branch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,10 +45,10 @@ jobs:
       - name: Cache scala dependencies
         uses: coursier/cache-action@v5
       - name: Run tests
-        if: matrix.scala != '3.0.0-RC3'
+        if: matrix.scala != '3.0.0'
         run: sbt ++${{ matrix.scala }}! test${{ matrix.platform }}
       - name: Run dotty tests
-        if: matrix.scala == '3.0.0-RC3' && matrix.platform == 'JVM'
+        if: matrix.scala == '3.0.0' && matrix.platform == 'JVM'
         run: sbt ++${{ matrix.scala }}! testJVM
 
   publish:

--- a/build.sbt
+++ b/build.sbt
@@ -40,12 +40,12 @@ lazy val root = project
     unusedCompileDependenciesFilter -= moduleFilter("org.scala-js", "scalajs-library")
   )
 
-val zioVersion                 = "1.0.7"
-val catsVersion                = "2.6.0"
-val catsEffectVersion          = "3.1.0"
-val catsMtlVersion             = "1.2.0"
-val disciplineScalaTestVersion = "2.1.4"
-val fs2Version                 = "3.0.2"
+val zioVersion                 = "1.0.8"
+val catsVersion                = "2.6.1"
+val catsEffectVersion          = "3.1.1"
+val catsMtlVersion             = "1.2.1"
+val disciplineScalaTestVersion = "2.1.5"
+val fs2Version                 = "3.0.3"
 val scalaJavaTimeVersion       = "2.3.0"
 
 lazy val interopCats = crossProject(JSPlatform, JVMPlatform)
@@ -54,16 +54,14 @@ lazy val interopCats = crossProject(JSPlatform, JVMPlatform)
   .settings(stdSettings("zio-interop-cats"))
   .settings(buildInfoSettings)
   .settings(
-    libraryDependencies += "dev.zio" %%% "zio" % zioVersion,
     libraryDependencies ++= Seq(
+      "dev.zio"       %%% "zio"             % zioVersion,
       "dev.zio"       %%% "zio-streams"     % zioVersion,
       "dev.zio"       %%% "zio-test"        % zioVersion,
       "org.typelevel" %%% "cats-effect-std" % catsEffectVersion,
       "org.typelevel" %%% "cats-mtl"        % catsMtlVersion,
       "co.fs2"        %%% "fs2-core"        % fs2Version
-    ).map { module =>
-      if (isDotty.value) module else module % Optional
-    },
+    ),
     libraryDependencies ++= Seq(
       "dev.zio"       %%% "zio-test-sbt"         % zioVersion,
       "org.typelevel" %%% "cats-testkit"         % catsVersion,

--- a/interop-cats/shared/src/main/scala/zio/interop/console/cats.scala
+++ b/interop-cats/shared/src/main/scala/zio/interop/console/cats.scala
@@ -26,11 +26,11 @@ object cats {
    * Prints the string representation of an object to the console.
    */
   def putStr[A](a: A)(implicit ev: Show[A]): ZIO[Console, Nothing, Unit] =
-    zio.console.putStr(ev.show(a))
+    zio.console.putStr(ev.show(a)).orDie
 
   /**
    * Prints the string representation of an object to the console, including a newline character.
    */
   def putStrLn[A](a: A)(implicit ev: Show[A]): ZIO[Console, Nothing, Unit] =
-    zio.console.putStrLn(ev.show(a))
+    zio.console.putStrLn(ev.show(a)).orDie
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,4 +8,3 @@ addSbtPlugin("com.github.cb372"                  % "sbt-explicit-dependencies" %
 addSbtPlugin("de.heikoseeberger"                 % "sbt-header"                % "5.6.0")
 addSbtPlugin("ch.epfl.scala"                     % "sbt-bloop"                 % "1.4.8")
 addSbtPlugin("com.geirsson"                      % "sbt-ci-release"            % "1.5.7")
-addSbtPlugin("ch.epfl.lamp"                      % "sbt-dotty"                 % "0.5.5")


### PR DESCRIPTION
- Update all related dependencies
- Update CI workflow
- Update API for Console to use orDie
- Remove sbt-dotty