### PR TITLE
RFC:  using % Provided

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -62,7 +62,7 @@ lazy val interopCats = crossProject(JSPlatform, JVMPlatform)
         "org.typelevel" %%% "cats-mtl"        % catsMtlVersion,
         "co.fs2"        %%% "fs2-core"        % fs2Version
       )
-      ("dev.zio" %%% "zio" % zioVersion) :: (if (scalaVersion.value.beginsWith("3")) optLibraries.map(_ % Optional) else optLibraries)
+      ("dev.zio" %%% "zio" % zioVersion) :: (if (scalaVersion.value.startsWith("3")) optLibraries.map(_ % Optional) else optLibraries)
     },
     libraryDependencies ++= Seq(
       "dev.zio"       %%% "zio-test-sbt"         % zioVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -55,7 +55,7 @@ lazy val interopCats = crossProject(JSPlatform, JVMPlatform)
   .settings(buildInfoSettings)
   .settings(
     libraryDependencies ++= Seq(
-      "dev.zio"       %%% "zio"             % zioVersion        % Provided,
+      "dev.zio"       %%% "zio"             % zioVersion,
       "dev.zio"       %%% "zio-streams"     % zioVersion        % Provided,
       "dev.zio"       %%% "zio-test"        % zioVersion        % Provided,
       "org.typelevel" %%% "cats-effect-std" % catsEffectVersion % Provided,

--- a/build.sbt
+++ b/build.sbt
@@ -54,14 +54,17 @@ lazy val interopCats = crossProject(JSPlatform, JVMPlatform)
   .settings(stdSettings("zio-interop-cats"))
   .settings(buildInfoSettings)
   .settings(
-    libraryDependencies ++= Seq(
-      "dev.zio"       %%% "zio"             % zioVersion,
-      "dev.zio"       %%% "zio-streams"     % zioVersion        % Provided,
-      "dev.zio"       %%% "zio-test"        % zioVersion        % Provided,
-      "org.typelevel" %%% "cats-effect-std" % catsEffectVersion % Provided,
-      "org.typelevel" %%% "cats-mtl"        % catsMtlVersion    % Provided,
-      "co.fs2"        %%% "fs2-core"        % fs2Version        % Provided
-    ),
+    libraryDependencies ++= {
+      val optLibraries = Seq(
+        "dev.zio"       %%% "zio"             % zioVersion,
+        "dev.zio"       %%% "zio-streams"     % zioVersion        % Provided,
+        "dev.zio"       %%% "zio-test"        % zioVersion        % Provided,
+        "org.typelevel" %%% "cats-effect-std" % catsEffectVersion % Provided,
+        "org.typelevel" %%% "cats-mtl"        % catsMtlVersion    % Provided,
+        "co.fs2"        %%% "fs2-core"        % fs2Version        % Provided
+      )
+      if (scalaVersion.value.beginsWith("3")) optLibraries.map(_ % Optional) else optLibraries
+    },
     libraryDependencies ++= Seq(
       "dev.zio"       %%% "zio-test-sbt"         % zioVersion,
       "org.typelevel" %%% "cats-testkit"         % catsVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -55,15 +55,14 @@ lazy val interopCats = crossProject(JSPlatform, JVMPlatform)
   .settings(buildInfoSettings)
   .settings(
     libraryDependencies ++= {
-      val optLibraries = Seq(
-        "dev.zio"       %%% "zio"             % zioVersion,
+      val optLibraries = List(
         "dev.zio"       %%% "zio-streams"     % zioVersion,
         "dev.zio"       %%% "zio-test"        % zioVersion,
         "org.typelevel" %%% "cats-effect-std" % catsEffectVersion,
         "org.typelevel" %%% "cats-mtl"        % catsMtlVersion,
         "co.fs2"        %%% "fs2-core"        % fs2Version
       )
-      if (scalaVersion.value.beginsWith("3")) optLibraries.map(_ % Optional) else optLibraries
+      ("dev.zio" %%% "zio" % zioVersion) :: if (scalaVersion.value.beginsWith("3")) optLibraries.map(_ % Optional) else optLibraries
     },
     libraryDependencies ++= Seq(
       "dev.zio"       %%% "zio-test-sbt"         % zioVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -55,12 +55,12 @@ lazy val interopCats = crossProject(JSPlatform, JVMPlatform)
   .settings(buildInfoSettings)
   .settings(
     libraryDependencies ++= Seq(
-      "dev.zio"       %%% "zio"             % zioVersion % Provided,
-      "dev.zio"       %%% "zio-streams"     % zioVersion % Provided,
-      "dev.zio"       %%% "zio-test"        % zioVersion % Provided,
+      "dev.zio"       %%% "zio"             % zioVersion        % Provided,
+      "dev.zio"       %%% "zio-streams"     % zioVersion        % Provided,
+      "dev.zio"       %%% "zio-test"        % zioVersion        % Provided,
       "org.typelevel" %%% "cats-effect-std" % catsEffectVersion % Provided,
-      "org.typelevel" %%% "cats-mtl"        % catsMtlVersion % Provided,
-      "co.fs2"        %%% "fs2-core"        % fs2Version % Provided
+      "org.typelevel" %%% "cats-mtl"        % catsMtlVersion    % Provided,
+      "co.fs2"        %%% "fs2-core"        % fs2Version        % Provided
     ),
     libraryDependencies ++= Seq(
       "dev.zio"       %%% "zio-test-sbt"         % zioVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -57,7 +57,7 @@ lazy val interopCats = crossProject(JSPlatform, JVMPlatform)
     libraryDependencies ++= Seq(
       "dev.zio"       %%% "zio"             % zioVersion,
       "dev.zio"       %%% "zio-streams"     % zioVersion,
-      "dev.zio"       %%% "zio-test"        % zioVersion,
+      "dev.zio"       %%% "zio-test"        % zioVersion % Test,
       "org.typelevel" %%% "cats-effect-std" % catsEffectVersion,
       "org.typelevel" %%% "cats-mtl"        % catsMtlVersion,
       "co.fs2"        %%% "fs2-core"        % fs2Version

--- a/build.sbt
+++ b/build.sbt
@@ -57,11 +57,11 @@ lazy val interopCats = crossProject(JSPlatform, JVMPlatform)
     libraryDependencies ++= {
       val optLibraries = Seq(
         "dev.zio"       %%% "zio"             % zioVersion,
-        "dev.zio"       %%% "zio-streams"     % zioVersion        % Provided,
-        "dev.zio"       %%% "zio-test"        % zioVersion        % Provided,
-        "org.typelevel" %%% "cats-effect-std" % catsEffectVersion % Provided,
-        "org.typelevel" %%% "cats-mtl"        % catsMtlVersion    % Provided,
-        "co.fs2"        %%% "fs2-core"        % fs2Version        % Provided
+        "dev.zio"       %%% "zio-streams"     % zioVersion,
+        "dev.zio"       %%% "zio-test"        % zioVersion,
+        "org.typelevel" %%% "cats-effect-std" % catsEffectVersion,
+        "org.typelevel" %%% "cats-mtl"        % catsMtlVersion,
+        "co.fs2"        %%% "fs2-core"        % fs2Version
       )
       if (scalaVersion.value.beginsWith("3")) optLibraries.map(_ % Optional) else optLibraries
     },

--- a/build.sbt
+++ b/build.sbt
@@ -62,7 +62,7 @@ lazy val interopCats = crossProject(JSPlatform, JVMPlatform)
         "org.typelevel" %%% "cats-mtl"        % catsMtlVersion,
         "co.fs2"        %%% "fs2-core"        % fs2Version
       )
-      val optLibraries = if (scalaVersion.value.startsWith("3")) optLibraries0.map(_ % Optional) else optLibraries0
+      val optLibraries = if (scalaVersion.value.startsWith("3")) optLibraries0 else optLibraries0.map(_ % Optional)
       ("dev.zio" %%% "zio" % zioVersion) :: optLibraries
     },
     libraryDependencies ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -55,12 +55,12 @@ lazy val interopCats = crossProject(JSPlatform, JVMPlatform)
   .settings(buildInfoSettings)
   .settings(
     libraryDependencies ++= Seq(
-      "dev.zio"       %%% "zio"             % zioVersion,
-      "dev.zio"       %%% "zio-streams"     % zioVersion,
-      "dev.zio"       %%% "zio-test"        % zioVersion % Test,
-      "org.typelevel" %%% "cats-effect-std" % catsEffectVersion,
-      "org.typelevel" %%% "cats-mtl"        % catsMtlVersion,
-      "co.fs2"        %%% "fs2-core"        % fs2Version
+      "dev.zio"       %%% "zio"             % zioVersion % Provided,
+      "dev.zio"       %%% "zio-streams"     % zioVersion % Provided,
+      "dev.zio"       %%% "zio-test"        % zioVersion % Provided,
+      "org.typelevel" %%% "cats-effect-std" % catsEffectVersion % Provided,
+      "org.typelevel" %%% "cats-mtl"        % catsMtlVersion % Provided,
+      "co.fs2"        %%% "fs2-core"        % fs2Version % Provided
     ),
     libraryDependencies ++= Seq(
       "dev.zio"       %%% "zio-test-sbt"         % zioVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -62,7 +62,7 @@ lazy val interopCats = crossProject(JSPlatform, JVMPlatform)
         "org.typelevel" %%% "cats-mtl"        % catsMtlVersion,
         "co.fs2"        %%% "fs2-core"        % fs2Version
       )
-      ("dev.zio" %%% "zio" % zioVersion) :: if (scalaVersion.value.beginsWith("3")) optLibraries.map(_ % Optional) else optLibraries
+      ("dev.zio" %%% "zio" % zioVersion) :: (if (scalaVersion.value.beginsWith("3")) optLibraries.map(_ % Optional) else optLibraries)
     },
     libraryDependencies ++= Seq(
       "dev.zio"       %%% "zio-test-sbt"         % zioVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -55,14 +55,15 @@ lazy val interopCats = crossProject(JSPlatform, JVMPlatform)
   .settings(buildInfoSettings)
   .settings(
     libraryDependencies ++= {
-      val optLibraries = List(
+      val optLibraries0 = List(
         "dev.zio"       %%% "zio-streams"     % zioVersion,
         "dev.zio"       %%% "zio-test"        % zioVersion,
         "org.typelevel" %%% "cats-effect-std" % catsEffectVersion,
         "org.typelevel" %%% "cats-mtl"        % catsMtlVersion,
         "co.fs2"        %%% "fs2-core"        % fs2Version
       )
-      ("dev.zio" %%% "zio" % zioVersion) :: (if (scalaVersion.value.startsWith("3")) optLibraries.map(_ % Optional) else optLibraries)
+      val optLibraries = if (scalaVersion.value.startsWith("3")) optLibraries0.map(_ % Optional) else optLibraries0
+      ("dev.zio" %%% "zio" % zioVersion) :: optLibraries
     },
     libraryDependencies ++= Seq(
       "dev.zio"       %%% "zio-test-sbt"         % zioVersion,


### PR DESCRIPTION
What would you guys think of making the dependencies on both zio-* and cats-* libraries as ` % Provided`?
I assume folks would bring in these libraries explicitly and want `interop-cats` only to bring the type classes for the libraries they actually use.
I learned that `interop-cats` depends firmly on all the zio-* and cats-* libs when I realized I have a zio-test JAR in my application image.