### PR TITLE
Fix Tests And Revert Cats Effect Version 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,8 +28,8 @@ inThisBuild(
 
 addCommandAlias("fmt", "all scalafmtSbt scalafmt test:scalafmt")
 addCommandAlias("check", "all scalafmtSbtCheck scalafmtCheck test:scalafmtCheck")
-addCommandAlias("testJVM", ";zioInteropCatsJVM/test;zioTestInteropCatsJVM/test;coreOnlyTestJVM/test")
-addCommandAlias("testJS", ";zioInteropCatsJS/test;zioTestInteropCatsJS/test;coreOnlyTestJS/test")
+addCommandAlias("testJVM", ";zioInteropCatsTestsJVM/test;zioTestInteropCatsJVM/test;coreOnlyTestJVM/test")
+addCommandAlias("testJS", ";zioInteropCatsTestsJS/test;zioTestInteropCatsJS/test;coreOnlyTestJS/test")
 
 lazy val root = project
   .in(file("."))
@@ -49,7 +49,7 @@ lazy val root = project
 
 val zioVersion                 = "2.0.0-M4"
 val catsVersion                = "2.6.1"
-val catsEffectVersion          = "3.2.9"
+val catsEffectVersion          = "3.1.1"
 val catsMtlVersion             = "1.2.1"
 val disciplineScalaTestVersion = "2.1.5"
 val fs2Version                 = "3.0.6"

--- a/zio-interop-cats-tests/shared/src/test/scala/zio/interop/CatsSpecBase.scala
+++ b/zio-interop-cats-tests/shared/src/test/scala/zio/interop/CatsSpecBase.scala
@@ -136,7 +136,7 @@ private[zio] trait CatsSpecBase
     zManagedEq[R, Nothing, A]
 
   implicit def cogenZIO[R: Arbitrary, E: Cogen, A: Cogen](implicit ticker: Ticker): Cogen[ZIO[R, E, A]] =
-    Cogen[Outcome[Option, E, A]].contramap { zio: ZIO[R, E, A] =>
+    Cogen[Outcome[Option, E, A]].contramap { (zio: ZIO[R, E, A]) =>
       Arbitrary.arbitrary[R].sample match {
         case Some(r) =>
           val result = unsafeRun(zio.provide(r))


### PR DESCRIPTION
The upgrade to version 3.2.9 caused some test failures that did not cause the build to fail due to a issue with the configuration of CI. We need to fix these tests as part of doing the version upgrade.