### PR TITLE
Update cats-effect version to 3.2.9

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -49,7 +49,7 @@ lazy val root = project
 
 val zioVersion                 = "1.0.12"
 val catsVersion                = "2.6.1"
-val catsEffectVersion          = "3.1.1"
+val catsEffectVersion          = "3.2.9"
 val catsMtlVersion             = "1.2.1"
 val disciplineScalaTestVersion = "2.1.5"
 val fs2Version                 = "3.0.6"

--- a/zio-interop-cats-tests/shared/src/test/scala/zio/interop/GenIOInteropCats.scala
+++ b/zio-interop-cats-tests/shared/src/test/scala/zio/interop/GenIOInteropCats.scala
@@ -26,27 +26,8 @@ trait GenIOInteropCats {
    */
   def genSuccess[E, A: Arbitrary]: Gen[IO[E, A]] = Gen.oneOf(genSyncSuccess[E, A], genAsyncSuccess[E, A])
 
-  /**
-   * Given a generator for `E`, produces a generator for `IO[E, A]` using the `IO.fail` constructor.
-   */
-  def genSyncFailure[E: Arbitrary, A]: Gen[IO[E, A]] = Arbitrary.arbitrary[E].map(IO.fail[E](_))
-
-  /**
-   * Given a generator for `E`, produces a generator for `IO[E, A]` using the `IO.async` constructor.
-   */
-  def genAsyncFailure[E: Arbitrary, A]: Gen[IO[E, A]] =
-    Arbitrary.arbitrary[E].map(err => IO.effectAsync[E, A](k => k(IO.fail(err))))
-
-  /**
-   * Randomly uses either `genSyncFailure` or `genAsyncFailure` with equal probability.
-   */
-  def genFailure[E: Arbitrary, A]: Gen[IO[E, A]] = Gen.oneOf(genSyncFailure[E, A], genAsyncFailure[E, A])
-
-  /**
-   * Randomly uses either `genSuccess` or `genFailure` with equal probability.
-   */
-  def genIO[E: Arbitrary, A: Arbitrary]: Gen[IO[E, A]] =
-    Gen.oneOf(genSuccess[E, A], genFailure[E, A])
+  def genIO[E, A: Arbitrary]: Gen[IO[E, A]] =
+    genSuccess[E, A]
 
   def genUIO[A: Arbitrary]: Gen[UIO[A]] =
     Gen.oneOf(genSuccess[Nothing, A], genIdentityTrans(genSuccess[Nothing, A]))


### PR DESCRIPTION
In the latest version cats-effect test framework uncomments additional test cases which run effects. Current zio.IO generator generates failures as well as successes, this is unnatural for ce.IO and the test framework doesn't expect such pre-failed values. Instead of providing pre-failed values the framework generates failures using `MonadError` when it's needed (for example in `fiberErrorIsOutcomeErrored` or `evalOnRaiseErrorIdentity` laws).