### PR TITLE
Fix tailRecM being not stack safe

### DIFF
--- a/zio-interop-cats-tests/shared/src/test/scala/zio/interop/catzSpec.scala
+++ b/zio-interop-cats-tests/shared/src/test/scala/zio/interop/catzSpec.scala
@@ -35,6 +35,7 @@ class catzSpec extends catzSpecZIOBase {
     implicit def ioArbitrary[A: Arbitrary]: Arbitrary[UIO[A]] = Arbitrary(genUIO[A])
     MonadTests[UIO].apply[Int, Int, Int]
   })
+  checkAllAsync("Monad[UIO]", implicit tc => ExtraMonadTests[UIO].monadExtras[Int])
   checkAllAsync(
     "ArrowChoice[ZIO]",
     implicit tc => ArrowChoiceTests[ZIO[*, Int, *]].arrowChoice[Int, Int, Int, Int, Int, Int]

--- a/zio-interop-cats/shared/src/main/scala/zio/interop/cats.scala
+++ b/zio-interop-cats/shared/src/main/scala/zio/interop/cats.scala
@@ -272,7 +272,7 @@ private class CatsConcurrent[R] extends CatsMonadError[R, Throwable] with Concur
     ZIO.uninterruptibleMask(_(fa).either.flatMap(f))
 }
 
-private class CatsMonadError[R, E] extends MonadError[ZIO[R, E, *], E] with StackSafeMonad[ZIO[R, E, *]] {
+private class CatsMonadError[R, E] extends MonadError[ZIO[R, E, *], E] {
   override final def pure[A](a: A): ZIO[R, E, A]                                         = ZIO.succeedNow(a)
   override final def map[A, B](fa: ZIO[R, E, A])(f: A => B): ZIO[R, E, B]                = fa.map(f)
   override final def flatMap[A, B](fa: ZIO[R, E, A])(f: A => ZIO[R, E, B]): ZIO[R, E, B] = fa.flatMap(f)
@@ -290,6 +290,12 @@ private class CatsMonadError[R, E] extends MonadError[ZIO[R, E, *], E] with Stac
   override final def raiseError[A](e: E): ZIO[R, E, A] = ZIO.fail(e)
 
   override final def attempt[A](fa: ZIO[R, E, A]): ZIO[R, E, Either[E, A]] = fa.either
+
+  override def tailRecM[A, B](a: A)(f: A => ZIO[R, E, Either[A, B]]): ZIO[R, E, B] =
+    flatMap(ZIO.effectSuspendTotal(f(a))) {
+      case Left(a)  => tailRecM(a)(f)
+      case Right(b) => pure(b)
+    }
 }
 
 /** lossy, throws away errors using the "first success" interpretation of SemigroupK */


### PR DESCRIPTION
Fixes #458.

Something to note is that the original implementation passes `tailRecMStackSafety` in cats (https://github.com/typelevel/cats/blob/e0784fc0d95b9c4eed0bb1ddce6c69e3fd9a4a4f/laws/src/main/scala/cats/laws/MonadLaws.scala#L39), which does not give `tailRecM` a recursive function.
This PR doesn't change the semantics in that case, but for the cases where `tailRecM` is given a recursive function like in `tailRecMConstructionStackSafety`, it prevents stack overflow during construction.

It's tested on v2.5.1.0, so some changes may be necessary to apply this to master.