### PR TITLE
Fix #503 implement `MonadCancel#canceled` by sending an external interrupt to current fiber via `Fiber.unsafeCurrentFiber`

### DIFF
--- a/zio-interop-cats-tests/jvm/src/test/scala/zio/interop/CatsInteropSpec.scala
+++ b/zio-interop-cats-tests/jvm/src/test/scala/zio/interop/CatsInteropSpec.scala
@@ -86,15 +86,17 @@ object CatsInteropSpec extends CatsRunnableSpec {
       for {
         counter <- F.ref("")
         _       <- F.guaranteeCase(
-                     F.onCancel(
-                       ZIO.collectAllPar(
-                         List(
-                           ZIO.unit.forever,
-                           counter.update(_ + "A") *> ZIO.die(new RuntimeException("x")).unit
-                         )
-                       ),
-                       counter.update(_ + "1")
-                     )
+                     F.onError(
+                       F.onCancel(
+                         ZIO.collectAllPar(
+                           List(
+                             ZIO.unit.forever,
+                             counter.update(_ + "A") *> ZIO.die(new RuntimeException("x")).unit
+                           )
+                         ),
+                         counter.update(_ + "1")
+                       )
+                     ) { case _ => counter.update(_ + "B") }
                    ) {
                      case Outcome.Errored(_)   => counter.update(_ + "C")
                      case Outcome.Canceled()   => counter.update(_ + "2")

--- a/zio-interop-cats-tests/jvm/src/test/scala/zio/interop/CatsInteropSpec.scala
+++ b/zio-interop-cats-tests/jvm/src/test/scala/zio/interop/CatsInteropSpec.scala
@@ -78,7 +78,7 @@ object CatsInteropSpec extends CatsRunnableSpec {
                      case Outcome.Succeeded(_) => counter.update(_ + "3")
                    }.run
         res     <- counter.get
-      } yield assertTrue(res == "ABC")
+      } yield assertTrue(!res.contains("1")) && assertTrue(res == "ABC")
     },
     testM("onCancel is not triggered by ZIO.parTraverse + ZIO.die https://github.com/zio/zio/issues/6911") {
       val F = Concurrent[Task]
@@ -103,7 +103,7 @@ object CatsInteropSpec extends CatsRunnableSpec {
                      case Outcome.Succeeded(_) => counter.update(_ + "3")
                    }.run
         res     <- counter.get
-      } yield assertTrue(res == "ABC")
+      } yield assertTrue(!res.contains("1")) && assertTrue(res == "ABC")
     },
     testM("onCancel is not triggered by ZIO.parTraverse + ZIO.interrupt https://github.com/zio/zio/issues/6911") {
       val F = Concurrent[Task]
@@ -128,7 +128,7 @@ object CatsInteropSpec extends CatsRunnableSpec {
                      case Outcome.Succeeded(_) => counter.update(_ + "3")
                    }.run
         res     <- counter.get
-      } yield assertTrue(res == "ABC")
+      } yield assertTrue(!res.contains("1")) && assertTrue(res == "ABC")
     }
   )
 }

--- a/zio-interop-cats-tests/jvm/src/test/scala/zio/interop/CatsInteropSpec.scala
+++ b/zio-interop-cats-tests/jvm/src/test/scala/zio/interop/CatsInteropSpec.scala
@@ -1,10 +1,10 @@
 package zio.interop
 
-import cats.effect.{ Async, IO as CIO, LiftIO }
+import cats.effect.{ Async, IO as CIO, LiftIO, Outcome }
 import cats.effect.kernel.{ Concurrent, Resource }
 import zio.interop.catz.*
 import zio.test.*
-import zio.{ Promise, Task }
+import zio.{ Promise, Task, ZIO }
 
 object CatsInteropSpec extends CatsRunnableSpec {
   def spec = suite("Cats interop")(
@@ -54,6 +54,81 @@ object CatsInteropSpec extends CatsRunnableSpec {
         sanityCheckCIO <- fromEffect(test[CIO])
         zioResult      <- test[Task]
       } yield zioResult && sanityCheckCIO
+    },
+    testM("onCancel is not triggered by ZIO.parTraverse + ZIO.fail https://github.com/zio/zio/issues/6911") {
+      val F = Concurrent[Task]
+
+      for {
+        counter <- F.ref("")
+        _       <- F.guaranteeCase(
+                     F.onError(
+                       F.onCancel(
+                         ZIO.collectAllPar(
+                           List(
+                             ZIO.unit.forever,
+                             counter.update(_ + "A") *> ZIO.fail(new RuntimeException("x")).unit
+                           )
+                         ),
+                         counter.update(_ + "1")
+                       )
+                     ) { case _ => counter.update(_ + "B") }
+                   ) {
+                     case Outcome.Errored(_)   => counter.update(_ + "C")
+                     case Outcome.Canceled()   => counter.update(_ + "2")
+                     case Outcome.Succeeded(_) => counter.update(_ + "3")
+                   }.run
+        res     <- counter.get
+      } yield assertTrue(res == "ABC")
+    },
+    testM("onCancel is not triggered by ZIO.parTraverse + ZIO.die https://github.com/zio/zio/issues/6911") {
+      val F = Concurrent[Task]
+
+      for {
+        counter <- F.ref("")
+        _       <- F.guaranteeCase(
+                     F.onError(
+                       F.onCancel(
+                         ZIO.collectAllPar(
+                           List(
+                             ZIO.unit.forever,
+                             counter.update(_ + "A") *> ZIO.die(new RuntimeException("x")).unit
+                           )
+                         ),
+                         counter.update(_ + "1")
+                       )
+                     ) { case _ => counter.update(_ + "B") }
+                   ) {
+                     case Outcome.Errored(_)   => counter.update(_ + "C")
+                     case Outcome.Canceled()   => counter.update(_ + "2")
+                     case Outcome.Succeeded(_) => counter.update(_ + "3")
+                   }.run
+        res     <- counter.get
+      } yield assertTrue(res == "ABC")
+    },
+    testM("onCancel is not triggered by ZIO.parTraverse + ZIO.interrupt https://github.com/zio/zio/issues/6911") {
+      val F = Concurrent[Task]
+
+      for {
+        counter <- F.ref("")
+        _       <- F.guaranteeCase(
+                     F.onError(
+                       F.onCancel(
+                         ZIO.collectAllPar(
+                           List(
+                             ZIO.unit.forever,
+                             counter.update(_ + "A") *> ZIO.interrupt.unit
+                           )
+                         ),
+                         counter.update(_ + "1")
+                       )
+                     ) { case _ => counter.update(_ + "B") }
+                   ) {
+                     case Outcome.Errored(_)   => counter.update(_ + "C")
+                     case Outcome.Canceled()   => counter.update(_ + "2")
+                     case Outcome.Succeeded(_) => counter.update(_ + "3")
+                   }.run
+        res     <- counter.get
+      } yield assertTrue(res == "ABC")
     }
   )
 }

--- a/zio-interop-cats-tests/jvm/src/test/scala/zio/interop/CatsInteropSpec.scala
+++ b/zio-interop-cats-tests/jvm/src/test/scala/zio/interop/CatsInteropSpec.scala
@@ -129,6 +129,22 @@ object CatsInteropSpec extends CatsRunnableSpec {
                    }.run
         res     <- counter.get
       } yield assertTrue(!res.contains("1")) && assertTrue(res == "ABC")
+    },
+    test("F.canceled.toEffect results in CancellationException, not BoxedException") {
+      val F = Concurrent[Task]
+
+      val exception: Option[Throwable] =
+        try {
+          F.canceled.toEffect[cats.effect.IO].unsafeRunSync()
+          None
+        } catch {
+          case t: Throwable => Some(t)
+        }
+
+      assertTrue(
+        !exception.get.getMessage.contains("Boxed Exception") &&
+          exception.get.getMessage.contains("The fiber was canceled")
+      )
     }
   )
 }

--- a/zio-interop-cats-tests/jvm/src/test/scala/zio/interop/CatsZManagedSyntaxSpec.scala
+++ b/zio-interop-cats-tests/jvm/src/test/scala/zio/interop/CatsZManagedSyntaxSpec.scala
@@ -17,13 +17,37 @@ object CatsZManagedSyntaxSpec extends CatsRunnableSpec {
   def spec =
     suite("CatsZManagedSyntaxSpec")(
       suite("toManaged")(
-        test("calls finalizers correctly when use is interrupted") {
+        test("calls finalizers correctly when use is externally interrupted") {
           val effects                          = new mutable.ListBuffer[Int]
           def res(x: Int): Resource[CIO, Unit] =
             Resource.makeCase(CIO.delay(effects += x).void) {
               case (_, Resource.ExitCase.Canceled) =>
                 CIO.delay(effects += x + 1).void
-              case _                               => CIO.unit
+              case (_, _)                          =>
+                CIO.unit
+            }
+
+          val testCase = {
+            val managed: ZManaged[Any, Throwable, Unit] = res(1).toManaged
+            Promise.make[Nothing, Unit].flatMap { latch =>
+              managed
+                .use(_ => latch.succeed(()) *> ZIO.never)
+                .forkDaemon
+                .flatMap(latch.await *> _.interrupt)
+            }
+          }
+
+          unsafeRun(testCase)
+          assert(effects.toList)(equalTo(List(1, 2)))
+        },
+        test("calls finalizers correctly when use is internally interrupted") {
+          val effects                          = new mutable.ListBuffer[Int]
+          def res(x: Int): Resource[CIO, Unit] =
+            Resource.makeCase(CIO.delay(effects += x).void) {
+              case (_, Resource.ExitCase.Errored(_)) =>
+                CIO.delay(effects += x + 1).void
+              case (_, _)                            =>
+                CIO.unit
             }
 
           val testCase = {
@@ -118,13 +142,35 @@ object CatsZManagedSyntaxSpec extends CatsRunnableSpec {
         }
       ),
       suite("toManagedZIO")(
-        test("calls finalizers correctly when use is interrupted") {
+        test("calls finalizers correctly when use is externally interrupted") {
           val effects                           = new mutable.ListBuffer[Int]
           def res(x: Int): Resource[Task, Unit] =
             Resource.makeCase(Task(effects += x).unit) {
               case (_, Resource.ExitCase.Canceled) =>
                 Task(effects += x + 1).unit
               case _                               => Task.unit
+            }
+
+          val testCase = {
+            val managed: ZManaged[Any, Throwable, Unit] = res(1).toManagedZIO
+            Promise.make[Nothing, Unit].flatMap { latch =>
+              managed
+                .use(_ => latch.succeed(()) *> ZIO.never)
+                .forkDaemon
+                .flatMap(latch.await *> _.interrupt)
+            }
+          }
+
+          unsafeRun(testCase)
+          assert(effects.toList)(equalTo(List(1, 2)))
+        },
+        test("calls finalizers correctly when use is internally interrupted") {
+          val effects                           = new mutable.ListBuffer[Int]
+          def res(x: Int): Resource[Task, Unit] =
+            Resource.makeCase(Task(effects += x).unit) {
+              case (_, Resource.ExitCase.Errored(_)) =>
+                Task(effects += x + 1).unit
+              case _                                 => Task.unit
             }
 
           val testCase = {

--- a/zio-interop-cats-tests/shared/src/test/scala/zio/interop/CatsSpecBase.scala
+++ b/zio-interop-cats-tests/shared/src/test/scala/zio/interop/CatsSpecBase.scala
@@ -114,6 +114,7 @@ private[zio] trait CatsSpecBase
   implicit def eqForUIO[A: Eq](implicit ticker: Ticker): Eq[UIO[A]] = { (uio1, uio2) =>
     val exit1 = unsafeRun(uio1)
     val exit2 = unsafeRun(uio2)
+//    println(s"comparing $exit1 $exit2")
     (exit1 eqv exit2) || {
       println(s"$exit1 was not equal to $exit2")
       false

--- a/zio-interop-cats-tests/shared/src/test/scala/zio/interop/CatsSpecBase.scala
+++ b/zio-interop-cats-tests/shared/src/test/scala/zio/interop/CatsSpecBase.scala
@@ -96,6 +96,8 @@ private[zio] trait CatsSpecBase
   implicit val eqForNothing: Eq[Nothing] =
     Eq.allEqual
 
+  // workaround for laws `evalOn local pure` & `executionContext commutativity`
+  // (ZIO cannot implement them at all due to `.executor.asEC` losing the original executionContext)
   implicit val eqForExecutionContext: Eq[ExecutionContext] =
     Eq.allEqual
 

--- a/zio-interop-cats-tests/shared/src/test/scala/zio/interop/GenIOInteropCats.scala
+++ b/zio-interop-cats-tests/shared/src/test/scala/zio/interop/GenIOInteropCats.scala
@@ -42,6 +42,8 @@ trait GenIOInteropCats {
   def genCancel[E, A: Arbitrary](implicit F: GenConcurrent[IO[E, _], ?]): Gen[IO[E, A]] =
     Arbitrary.arbitrary[A].map(F.canceled.as(_))
 
+  def genNever: Gen[UIO[Nothing]] = ZIO.never
+
   def genIO[E: Arbitrary, A: Arbitrary](implicit
     arbThrowable: Arbitrary[Throwable],
     F: GenConcurrent[IO[E, _], ?]
@@ -52,7 +54,8 @@ trait GenIOInteropCats {
         genFail[E, A],
         genDie,
         genInternalInterrupt,
-        genCancel[E, A]
+        genCancel[E, A],
+        genNever
       )
     else
       genSuccess[E, A]

--- a/zio-interop-cats-tests/shared/src/test/scala/zio/interop/GenIOInteropCats.scala
+++ b/zio-interop-cats-tests/shared/src/test/scala/zio/interop/GenIOInteropCats.scala
@@ -58,7 +58,10 @@ trait GenIOInteropCats {
         genNever
       )
     else
-      genSuccess[E, A]
+      Gen.oneOf(
+        genSuccess[E, A],
+        genNever
+      )
 
   def genUIO[A: Arbitrary]: Gen[UIO[A]] =
     Gen.oneOf(genSuccess[Nothing, A], genIdentityTrans(genSuccess[Nothing, A]))

--- a/zio-interop-cats-tests/shared/src/test/scala/zio/interop/GenIOInteropCats.scala
+++ b/zio-interop-cats-tests/shared/src/test/scala/zio/interop/GenIOInteropCats.scala
@@ -1,14 +1,21 @@
 package zio.interop
 
+import cats.effect.GenConcurrent
 import org.scalacheck.*
 import zio.*
 
-/**
- * Temporary fork of zio.GenIO that overrides `genParallel` with ZManaged-based code
- * instead of `io.zipPar(parIo).map(_._1)`
- * because ZIP-PAR IS NON-DETERMINISTIC IN ITS SPAWNED EC TASKS (required for TestContext equality)
- */
 trait GenIOInteropCats {
+
+  // FIXME generating anything but success (even genFail)
+  //  surfaces multiple further unaddressed law failures
+  def betterGenerators: Boolean = false
+
+  // FIXME cats conversion surfaces failures in the following laws:
+  //  `async left is uncancelable sequenced raiseError`
+  //  `async right is uncancelable sequenced pure`
+  //  `applicativeError onError raise`
+  //  `canceled sequences onCanceled in order`
+  def catsConversionGenerator: Boolean = false
 
   /**
    * Given a generator for `A`, produces a generator for `IO[E, A]` using the `IO.point` constructor.
@@ -26,8 +33,29 @@ trait GenIOInteropCats {
    */
   def genSuccess[E, A: Arbitrary]: Gen[IO[E, A]] = Gen.oneOf(genSyncSuccess[E, A], genAsyncSuccess[E, A])
 
-  def genIO[E, A: Arbitrary]: Gen[IO[E, A]] =
-    genSuccess[E, A]
+  def genFail[E: Arbitrary, A]: Gen[IO[E, A]] = Arbitrary.arbitrary[E].map(IO.fail[E](_))
+
+  def genDie(implicit arbThrowable: Arbitrary[Throwable]): Gen[UIO[Nothing]] = arbThrowable.arbitrary.map(IO.die(_))
+
+  def genInternalInterrupt: Gen[UIO[Nothing]] = ZIO.interrupt
+
+  def genCancel[E, A: Arbitrary](implicit F: GenConcurrent[IO[E, _], ?]): Gen[IO[E, A]] =
+    Arbitrary.arbitrary[A].map(F.canceled.as(_))
+
+  def genIO[E: Arbitrary, A: Arbitrary](implicit
+    arbThrowable: Arbitrary[Throwable],
+    F: GenConcurrent[IO[E, _], ?]
+  ): Gen[IO[E, A]] =
+    if (betterGenerators)
+      Gen.oneOf(
+        genSuccess[E, A],
+        genFail[E, A],
+        genDie,
+        genInternalInterrupt,
+        genCancel[E, A]
+      )
+    else
+      genSuccess[E, A]
 
   def genUIO[A: Arbitrary]: Gen[UIO[A]] =
     Gen.oneOf(genSuccess[Nothing, A], genIdentityTrans(genSuccess[Nothing, A]))
@@ -98,17 +126,8 @@ trait GenIOInteropCats {
     Gen.const(io.flatMap(a => IO.succeed(a)))
 
   private def genOfRace[E, A](io: IO[E, A]): Gen[IO[E, A]] =
-    Gen.const(io.raceFirst(ZIO.never.interruptible))
+    Gen.const(io.interruptible.raceFirst(ZIO.never.interruptible))
 
   private def genOfParallel[E, A](io: IO[E, A])(gen: Gen[IO[E, A]]): Gen[IO[E, A]] =
-    gen.map { parIo =>
-      // this should work, but generates more random failures on CI
-//      io.interruptible.zipPar(parIo.interruptible).map(_._1)
-      Promise.make[Nothing, Unit].flatMap { p =>
-        ZManaged
-          .fromEffect(parIo *> p.succeed(()))
-          .fork
-          .use_(p.await *> io)
-      }
-    }
+    gen.map(parIo => io.interruptible.zipPar(parIo.interruptible).map(_._1))
 }

--- a/zio-interop-cats-tests/shared/src/test/scala/zio/interop/ZioSpecBase.scala
+++ b/zio-interop-cats-tests/shared/src/test/scala/zio/interop/ZioSpecBase.scala
@@ -31,8 +31,7 @@ private[interop] trait ZioSpecBase extends CatsSpecBase with ZioSpecBaseLowPrior
       Gen.oneOf(
         e.arbitrary.map(Cause.Fail(_)),
         Arbitrary.arbitrary[Throwable].map(Cause.Die(_)),
-        // Generating interrupt failures causes law failures (`canceled`/`Outcome.Canceled` are ill-defined as of now https://github.com/zio/interop-cats/issues/503#issuecomment-1157101175=)
-//        Gen.long.flatMap(l1 => Gen.long.map(l2 => Cause.Interrupt(Fiber.Id(l1, l2)))),
+        Gen.long.flatMap(l1 => Gen.long.map(l2 => Cause.Interrupt(Fiber.Id(l1, l2)))),
         Gen.delay(self.map(Cause.Traced(_, ZTrace(Fiber.Id.None, Nil, Nil, None)))),
         Gen.delay(self.map(Cause.stackless)),
         Gen.delay(self.flatMap(e1 => self.map(e2 => Cause.Both(e1, e2)))),

--- a/zio-interop-cats/js/src/main/scala/zio/interop/ZioAsync.scala
+++ b/zio-interop-cats/js/src/main/scala/zio/interop/ZioAsync.scala
@@ -1,7 +1,7 @@
 package zio.interop
 
-import cats.effect.kernel.{ Async, Cont, Outcome, Sync, Unique }
-import zio.{ Exit, RIO, Ref, ZIO }
+import cats.effect.kernel.{ Async, Cont, Sync, Unique }
+import zio.{ RIO, ZIO }
 
 import scala.concurrent.{ ExecutionContext, Future }
 
@@ -39,20 +39,19 @@ private abstract class ZioAsync[R]
     ZIO.effect(thunk)
 
   override final def async[A](k: (Either[Throwable, A] => Unit) => F[Option[F[Unit]]]): F[A] =
-    for {
-      cancelerRef <- Ref.make[Option[F[Unit]]](None)
-      res         <- guaranteeCase(
-                       ZIO.effectAsyncM[R, Throwable, A] { resume =>
-                         k(exitEither => resume(ZIO.fromEither(exitEither))).onExit {
-                           case Exit.Success(maybeCanceler) => cancelerRef.set(maybeCanceler)
-                           case _: Exit.Failure[?]          => ZIO.unit
-                         }
-                       }
-                     ) {
-                       case Outcome.Canceled() => cancelerRef.get.flatMap(ZIO.foreach(_)(identity)).unit
-                       case _                  => ZIO.unit
-                     }
-    } yield res
+    ZIO.effectSuspendTotal {
+      val p = scala.concurrent.Promise[Either[Throwable, A]]()
+
+      def get: F[A] =
+        ZIO.fromFuture(_ => p.future).flatMap(ZIO.fromEither(_))
+
+      ZIO.uninterruptibleMask(restore =>
+        k({ e => p.trySuccess(e); () }).flatMap {
+          case Some(canceler) => onCancel(restore(get), canceler.orDie)
+          case None           => restore(get)
+        }
+      )
+    }
 
   override final def async_[A](k: (Either[Throwable, A] => Unit) => Unit): F[A] =
     ZIO.effectAsync(register => k(register.compose(fromEither)))

--- a/zio-interop-cats/js/src/main/scala/zio/interop/ZioAsync.scala
+++ b/zio-interop-cats/js/src/main/scala/zio/interop/ZioAsync.scala
@@ -43,7 +43,7 @@ private abstract class ZioAsync[R]
       val p = scala.concurrent.Promise[Either[Throwable, A]]()
 
       def get: F[A] =
-        ZIO.fromFuture(_ => p.future).flatMap(ZIO.fromEither(_))
+        ZIO.fromFuture(_ => p.future).flatMap[Any, Throwable, A](ZIO.fromEither(_))
 
       ZIO.uninterruptibleMask(restore =>
         k({ e => p.trySuccess(e); () }).flatMap {

--- a/zio-interop-cats/jvm/src/main/scala/zio/interop/ZioAsync.scala
+++ b/zio-interop-cats/jvm/src/main/scala/zio/interop/ZioAsync.scala
@@ -48,7 +48,7 @@ private abstract class ZioAsync[R]
       val p = scala.concurrent.Promise[Either[Throwable, A]]()
 
       def get: F[A] =
-        ZIO.fromFuture(_ => p.future).flatMap(ZIO.fromEither(_))
+        ZIO.fromFuture(_ => p.future).flatMap[Any, Throwable, A](ZIO.fromEither(_))
 
       ZIO.uninterruptibleMask(restore =>
         k({ e => p.trySuccess(e); () }).flatMap {

--- a/zio-interop-cats/shared/src/main/scala/zio/interop/cats.scala
+++ b/zio-interop-cats/shared/src/main/scala/zio/interop/cats.scala
@@ -332,7 +332,7 @@ private abstract class ZioConcurrent[R, E, E1]
                           toOutcomeOtherFiber(interruptedA)(exit).map(outcome => Left((outcome, toFiber(interruptedB)(fiber)))),
                         (exit, fiber) =>
                           toOutcomeOtherFiber(interruptedB)(exit).map(outcome => Right((toFiber(interruptedA)(fiber), outcome)))
-                      ).resetForkScope
+                      )
     } yield res
 
   override final def both[A, B](fa: F[A], fb: F[B]): F[(A, B)] =

--- a/zio-interop-cats/shared/src/main/scala/zio/interop/cats.scala
+++ b/zio-interop-cats/shared/src/main/scala/zio/interop/cats.scala
@@ -313,9 +313,6 @@ private abstract class ZioConcurrent[R, E, E1]
     }
   }
 
-  override final def onError[A](fa: ZIO[R, E, A])(pf: PartialFunction[E1, ZIO[R, E, Unit]]): ZIO[R, E, A] =
-    guaranteeCase(fa) { case Outcome.Errored(e) => pf.applyOrElse(e, (_: E1) => ZIO.unit); case _ => ZIO.unit }
-
   override final def onCancel[A](fa: F[A], fin: F[Unit]): F[A] =
     guaranteeCase(fa) { case Outcome.Canceled() => fin.orDieWith(toThrowableOrFiberFailure); case _ => ZIO.unit }
 

--- a/zio-interop-cats/shared/src/main/scala/zio/interop/catszmanaged.scala
+++ b/zio-interop-cats/shared/src/main/scala/zio/interop/catszmanaged.scala
@@ -104,13 +104,13 @@ final class ZManagedSyntax[R, E, A](private val managed: ZManaged[R, E, A]) exte
       }
   }
 
-  def toResource[F[_]: Async](implicit R: Runtime[R], ev: E <:< Throwable): Resource[F, A] = {
-    import zio.interop.catz.generic.*
-
-    toResourceZIO.mapK(new (ZIO[R, E, _] ~> F) {
-      override def apply[B](zio: ZIO[R, E, B]): F[B] = toEffect[F, R, B](zio.mapError(ev))
-    })
-  }
+  def toResource[F[_]: Async](implicit R: Runtime[R], ev: E <:< Throwable): Resource[F, A] =
+    managed
+      .mapError(ev)
+      .toResourceZIO
+      .mapK(new (ZIO[R, Throwable, _] ~> F) {
+        override def apply[B](zio: ZIO[R, Throwable, B]): F[B] = toEffect[F, R, B](zio)
+      })
 }
 
 trait CatsEffectZManagedInstances {

--- a/zio-interop-cats/shared/src/main/scala/zio/interop/catszmanaged.scala
+++ b/zio-interop-cats/shared/src/main/scala/zio/interop/catszmanaged.scala
@@ -66,7 +66,7 @@ final class ZIOResourceSyntax[R, E <: Throwable, A](private val resource: Resour
                 r               <- ZIO.environment[(R, ReleaseMap)]
                 af              <- allocate.resource(toPoll(restore)).provide(r._1)
                 (a, release)     = af
-                releaseMapEntry <- r._2.add(exit => release(toExitCase(exit)).provide(r._1).orDie)
+                releaseMapEntry <- r._2.add(toExitCaseThisFiber(_).flatMap(release).provide(r._1).orDie)
               } yield (releaseMapEntry, a)
             }
           }


### PR DESCRIPTION
* Fix #503 implement `MonadCancel#canceled` by sending an external interrupt to current fiber via `Fiber.unsafeCurrentFiber`
* Workaround zio/zio#6911 Only consider the *current* fiber being interrupted as `Outcome.Canceled`
* Consider internal interruption & Die to be `Outcome.Errored`
* Trigger `MonadCancel#onCancel` only if the *current* fiber is being interrupted
* Only trigger `MonadCancel#onCancel` on interruption, instead of any Exit status that's not a typed error
* Implement `MonadCancel#bracketFull`, `bracketCase` & `guaranteeCase`
* Redefine `toEffect` using `unsafeRunAsyncCancelable` to avoid getting a `BoxedException` leaking from underlying Future when `MonadCancel#canceled` is used inside the converted effect.
* Change the implementation of Async#async to follow `async left is uncancelable sequenced raiseError` law.

  Consider the law code:

  ```scala
  // format: off
  def asyncLeftIsUncancelableSequencedRaiseError[A](e: Throwable, fu: F[Unit]) =
    (F.async[A](k => F.delay(k(Left(e))) >> fu.as(None)) <* F.unit) <-> (F.uncancelable(_ => fu) >> F.raiseError(e))
  // format: on
  ```

  if `fu` is `F.never`, then an implementation based on ZIO.effectAsyncM can never satisfy this law,
because it runs the register code on a separate fiber and ignores its effect.
The law clearly states that register effect must run first and must run on the same fiber
as the callback listener, so as to supercede it.
