### PR TITLE
Bring back interoperability between ZManaged and Resource for Cats-Effect 2.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -58,7 +58,7 @@ lazy val zioInteropCats = crossProject(JSPlatform, JVMPlatform)
   .settings(
     libraryDependencies ++= Seq(
       "dev.zio"       %%% "zio"             % zioVersion,
-      "dev.zio"       %%% "zio-managed"             % zioVersion,
+      "dev.zio"       %%% "zio-managed"     % zioVersion,
       "dev.zio"       %%% "zio-stacktracer" % zioVersion,
       "dev.zio"       %%% "zio-streams"     % zioVersion,
       "org.typelevel" %%% "cats-effect"     % "2.5.1",

--- a/build.sbt
+++ b/build.sbt
@@ -58,6 +58,7 @@ lazy val zioInteropCats = crossProject(JSPlatform, JVMPlatform)
   .settings(
     libraryDependencies ++= Seq(
       "dev.zio"       %%% "zio"             % zioVersion,
+      "dev.zio"       %%% "zio-managed"             % zioVersion,
       "dev.zio"       %%% "zio-stacktracer" % zioVersion,
       "dev.zio"       %%% "zio-streams"     % zioVersion,
       "org.typelevel" %%% "cats-effect"     % "2.5.1",

--- a/zio-interop-cats-tests/jvm/src/test/scala/zio/interop/CatsScopedSyntaxSpec.scala
+++ b/zio-interop-cats-tests/jvm/src/test/scala/zio/interop/CatsScopedSyntaxSpec.scala
@@ -1,11 +1,11 @@
 package zio.interop
 
-import cats.effect.{ExitCase, Resource, IO => CIO}
+import cats.effect.{ ExitCase, Resource, IO => CIO }
 import zio.interop.catz._
 import zio.managed.ZManaged
 import zio.test.Assertion._
 import zio.test._
-import zio.{Exit, Scope, Task, Unsafe, ZIO}
+import zio.{ Exit, Scope, Task, Unsafe, ZIO }
 
 import scala.collection.mutable
 
@@ -229,9 +229,9 @@ object CatsScopedSyntaxSpec extends ZIOSpecDefault {
             Resource.make(CIO.delay { effects += x }.void)(_ => CIO.delay { effects += x }.void)
 
           def managed(x: Int): ZManaged[Any, Throwable, Unit] =
-            ZManaged.acquireReleaseWith(ZIO.succeed(effects += x))(_ => ZIO.succeed(effects += x))
+            ZManaged
+              .acquireReleaseWith(ZIO.succeed(effects += x))(_ => ZIO.succeed(effects += x))
               .flatMap(_ => ZManaged.unit)
-
 
           val testCase = {
             val managed1: ZManaged[Any, Throwable, Unit] = res(1).toManaged
@@ -390,7 +390,7 @@ object CatsScopedSyntaxSpec extends ZIOSpecDefault {
 
           val testCase = {
             val managed: ZManaged[Any, Throwable, Unit] = res(1).toManagedZIO
-            managed.use(_ =>ZIO.fail(new RuntimeException()).unit)
+            managed.use(_ => ZIO.fail(new RuntimeException()).unit)
           }
 
           for {
@@ -457,9 +457,9 @@ object CatsScopedSyntaxSpec extends ZIOSpecDefault {
             Resource.make(ZIO.succeed { effects += x }.unit)(_ => ZIO.succeed { effects += x }.unit)
 
           def managed(x: Int): ZManaged[Any, Throwable, Unit] =
-            ZManaged.acquireReleaseWith(ZIO.succeed(effects += x))(_ => ZIO.succeed(effects += x))
+            ZManaged
+              .acquireReleaseWith(ZIO.succeed(effects += x))(_ => ZIO.succeed(effects += x))
               .flatMap(_ => ZManaged.unit)
-
 
           val testCase = {
             val managed1: ZManaged[Any, Throwable, Unit] = res(1).toManagedZIO

--- a/zio-interop-cats-tests/jvm/src/test/scala/zio/interop/CatsScopedSyntaxSpec.scala
+++ b/zio-interop-cats-tests/jvm/src/test/scala/zio/interop/CatsScopedSyntaxSpec.scala
@@ -1,10 +1,11 @@
 package zio.interop
 
-import cats.effect.{ ExitCase, Resource, IO => CIO }
+import cats.effect.{ExitCase, Resource, IO => CIO}
 import zio.interop.catz._
+import zio.managed.ZManaged
 import zio.test.Assertion._
 import zio.test._
-import zio.{ Exit, Scope, Task, Unsafe, ZIO }
+import zio.{Exit, Scope, Task, Unsafe, ZIO}
 
 import scala.collection.mutable
 
@@ -121,6 +122,121 @@ object CatsScopedSyntaxSpec extends ZIOSpecDefault {
             val scoped1: ZIO[Scope, Throwable, Unit] = res(1).toScoped
             val scoped2: ZIO[Scope, Throwable, Unit] = scope(2)
             Scope.make.flatMap(_.use[Any](scoped1 *> scoped2))
+          }
+
+          for {
+            _       <- testCase
+            effects <- ZIO.succeed(effects.toList)
+          } yield assert(effects)(equalTo(List(1, 2, 2, 1)))
+        }
+      ),
+      suite("toManaged")(
+        test("calls finalizers correctly when use is interrupted") {
+          val effects = new mutable.ListBuffer[Int]
+          def res(x: Int): Resource[CIO, Unit] =
+            Resource.makeCase(CIO.delay { effects += x }.void) {
+              case (_, ExitCase.Canceled) =>
+                CIO.delay { effects += x + 1 }.void
+              case _ => CIO.unit
+            }
+
+          val testCase = {
+            val managed: ZManaged[Any, Throwable, Unit] = res(1).toManaged
+            managed.use(_ => ZIO.interrupt.unit)
+          }
+
+          for {
+            _       <- testCase.orElse(ZIO.unit)
+            effects <- ZIO.succeed(effects.toList)
+          } yield assert(effects)(equalTo(List(1, 2)))
+        },
+        test("calls finalizers correctly when use has failed") {
+          val effects = new mutable.ListBuffer[Int]
+          def res(x: Int): Resource[CIO, Unit] =
+            Resource.makeCase(CIO.delay { effects += x }.void) {
+              case (_, ExitCase.Error(_)) =>
+                CIO.delay { effects += x + 1 }.void
+              case _ =>
+                CIO.unit
+            }
+
+          val testCase = {
+            val managed: ZManaged[Any, Throwable, Unit] = res(1).toManaged
+            managed.use(_ => ZIO.fail(new RuntimeException()).unit)
+          }
+
+          for {
+            _       <- testCase.orElse(ZIO.unit)
+            effects <- ZIO.succeed(effects.toList)
+          } yield assert(effects)(equalTo(List(1, 2)))
+        },
+        test("calls finalizers correctly when use has died") {
+          val effects = new mutable.ListBuffer[Int]
+          def res(x: Int): Resource[CIO, Unit] =
+            Resource.makeCase(CIO.delay { effects += x }.void) {
+              case (_, ExitCase.Error(_)) =>
+                CIO.delay { effects += x + 1 }.void
+              case _ =>
+                CIO.unit
+            }
+
+          val testCase = {
+            val managed: ZManaged[Scope, Throwable, Unit] = res(1).toManaged
+            managed.use(_ => ZIO.die(new RuntimeException()).unit)
+          }
+
+          for {
+            _       <- testCase.sandbox.orElse(ZIO.unit)
+            effects <- ZIO.succeed(effects.toList)
+          } yield assert(effects)(equalTo(List(1, 2)))
+        },
+        test("calls finalizers should not run if exception is thrown in acquisition") {
+          val effects = new mutable.ListBuffer[Int]
+          def res(x: Int): Resource[CIO, Unit] =
+            Resource.make(CIO.delay(effects += x) *> CIO.delay(throw new RuntimeException()).void)(
+              _ => CIO.delay { effects += x + 1 }.void
+            )
+
+          val testCase = {
+            val managed: ZManaged[Any, Throwable, Unit] = res(1).toManaged
+            managed.use(_ => ZIO.unit)
+          }
+
+          for {
+            _       <- testCase.sandbox.orElse(ZIO.unit)
+            effects <- ZIO.succeed(effects.toList)
+          } yield assert(effects)(equalTo(List(1)))
+        },
+        test("calls finalizers correctly when using the resource") {
+          val effects = new mutable.ListBuffer[Int]
+          def res(x: Int): Resource[CIO, Unit] =
+            Resource.make(CIO.delay { effects += x }.void)(_ => CIO.delay { effects += x }.void)
+
+          val testCase = {
+            val managed: ZManaged[Any, Throwable, Unit] = res(1).toManaged
+            managed.use(_ => ZIO.unit)
+          }
+
+          for {
+            _       <- testCase
+            effects <- ZIO.succeed(effects.toList)
+          } yield assert(effects)(equalTo(List(1, 1)))
+        },
+        test("composing with other scoped should calls finalizers in correct order") {
+
+          val effects = new mutable.ListBuffer[Int]
+          def res(x: Int): Resource[CIO, Unit] =
+            Resource.make(CIO.delay { effects += x }.void)(_ => CIO.delay { effects += x }.void)
+
+          def managed(x: Int): ZManaged[Any, Throwable, Unit] =
+            ZManaged.acquireReleaseWith(ZIO.succeed(effects += x))(_ => ZIO.succeed(effects += x))
+              .flatMap(_ => ZManaged.unit)
+
+
+          val testCase = {
+            val managed1: ZManaged[Any, Throwable, Unit] = res(1).toManaged
+            val managed2: ZManaged[Any, Throwable, Unit] = managed(2)
+            (managed1 *> managed2).use(_ => ZIO.unit)
           }
 
           for {

--- a/zio-interop-cats/shared/src/main/scala-2/zio/interop/catsscoped2.scala
+++ b/zio-interop-cats/shared/src/main/scala-2/zio/interop/catsscoped2.scala
@@ -17,9 +17,9 @@
 package zio
 package interop
 
-import cats.effect.Resource.{Allocate, Bind, Suspend}
+import cats.effect.Resource.{ Allocate, Bind, Suspend }
 import cats.effect.Resource
-import zio.managed.{Reservation, ZManaged}
+import zio.managed.{ Reservation, ZManaged }
 
 final class ZIOResourceSyntax[R, E <: Throwable, A](private val resource: Resource[ZIO[R, E, *], A]) extends AnyVal {
 

--- a/zio-interop-cats/shared/src/main/scala/zio/interop/catsscoped.scala
+++ b/zio-interop-cats/shared/src/main/scala/zio/interop/catsscoped.scala
@@ -14,14 +14,16 @@
  * limitations under the License.
  */
 
-package zio
-package interop
+package zio.interop
 
 import cats.arrow.FunctionK
-import cats.effect.{ Async, Effect, ExitCase, LiftIO, Resource }
-import cats.~>
-import zio.interop.CatsResourceObjectSyntax.FromScopedZIOPartiallyApplied
-import zio.interop.CatsResourceObjectSyntax.FromScopedPartiallyApplied
+import zio.internal.stacktracer.{InteropTracer, Tracer => CoreTracer}
+import cats.effect.{Async, Effect, ExitCase, LiftIO, Resource, Sync, IO => CIO}
+import cats.{Bifunctor, Monad, MonadError, Monoid, Semigroup, SemigroupK, ~>}
+import zio.interop.CatsResourceObjectSyntax.{FromScopedPartiallyApplied, FromScopedZIOPartiallyApplied}
+import zio.{CanFail, ExecutionStrategy, Scope, Trace, ZIO}
+import zio.managed.ZManaged
+import zio.managed.ZManaged.ReleaseMap
 
 trait CatsScopedSyntax {
   import scala.language.implicitConversions
@@ -35,6 +37,8 @@ trait CatsScopedSyntax {
   implicit final def catsIOResourceObjectSyntax(unused: Resource.type): CatsResourceObjectSyntax =
     new CatsResourceObjectSyntax(unused)
 
+  implicit final def zManagedSyntax[R, E, A](managed: ZManaged[R, E, A]): ZManagedSyntax[R, E, A] =
+    new ZManagedSyntax(managed)
 }
 
 final class CatsIOResourceSyntax[F[_], A](private val resource: Resource[F, A]) extends AnyVal {
@@ -55,6 +59,56 @@ final class CatsIOResourceSyntax[F[_], A](private val resource: Resource[F, A]) 
       )
     ).toScopedZIO
   }
+
+  /**
+   * Convert a cats Resource into a ZManaged.
+   * Beware that unhandled error during release of the resource will result in the fiber dying.
+   */
+  def toManaged[R](implicit L: LiftIO[ZIO[R, Throwable, *]], F: Effect[F]): ZManaged[R, Throwable, A] = {
+    import catz.core._
+
+    new ZIOResourceSyntax(
+      resource.mapK(
+        new ~>[F, ZIO[R, Throwable, *]] {
+          def apply[A](fa: F[A]): ZIO[R, Throwable, A] =
+            L liftIO F.toIO(fa)
+        }
+      )
+    ).toManagedZIO
+  }
+}
+
+final class ZManagedSyntax[R, E, A](private val managed: ZManaged[R, E, A]) extends AnyVal {
+
+  def toResourceZIO(implicit trace: Trace): Resource[ZIO[R, E, *], A] =
+    Resource
+      .applyCase[ZIO[R, E, *], ReleaseMap](
+        ZManaged.ReleaseMap.make.map(
+          releaseMap =>
+            (
+              releaseMap,
+              (exitCase: ExitCase[Throwable]) =>
+                releaseMap.releaseAll(exitCaseToExit(exitCase), ExecutionStrategy.Sequential).unit
+            )
+        )
+      )
+      .flatMap(
+        releaseMap =>
+          Resource.suspend(
+            ZManaged.currentReleaseMap.locally(releaseMap) {
+              managed.zio.map { a =>
+                Resource.applyCase(ZIO.succeedNow((a._2, (_: ExitCase[Throwable]) => ZIO.unit)))
+              }
+            }
+          )
+      )
+
+  def toResource[F[_]](implicit F: Async[F], ev: Effect[ZIO[R, E, *]], trace: Trace): Resource[F, A] =
+    toResourceZIO.mapK(new FunctionK[ZIO[R, E, *], F] {
+      def apply[A](fa: ZIO[R, E, A]): F[A] =
+        F liftIO ev.toIO(fa)
+    })
+
 }
 
 final class CatsResourceObjectSyntax(private val resource: Resource.type) extends AnyVal {
@@ -66,6 +120,7 @@ final class CatsResourceObjectSyntax(private val resource: Resource.type) extend
     new FromScopedPartiallyApplied[F, R]
 
 }
+
 
 object CatsResourceObjectSyntax {
 
@@ -101,4 +156,119 @@ object CatsResourceObjectSyntax {
         })
   }
 
+}
+
+trait CatsEffectZManagedInstances {
+
+  implicit def liftIOZManagedInstances[R](
+                                           implicit ev: LiftIO[ZIO[R, Throwable, *]]
+                                         ): LiftIO[ZManaged[R, Throwable, *]] =
+    new LiftIO[ZManaged[R, Throwable, *]] {
+      override def liftIO[A](ioa: CIO[A]): ZManaged[R, Throwable, A] =
+        ZManaged.fromZIO(ev.liftIO(ioa))(CoreTracer.newTrace)
+    }
+
+  implicit def syncZManagedInstances[R]: Sync[ZManaged[R, Throwable, *]] =
+    new CatsZManagedSync[R]
+
+}
+
+trait CatsZManagedInstances extends CatsZManagedInstances1 {
+
+  implicit def monadErrorZManagedInstances[R, E]: MonadError[ZManaged[R, E, *], E] =
+    new CatsZManagedMonadError
+
+  implicit def monoidZManagedInstances[R, E, A](implicit ev: Monoid[A]): Monoid[ZManaged[R, E, A]] =
+    new Monoid[ZManaged[R, E, A]] {
+      override def empty: ZManaged[R, E, A] = ZManaged.succeedNow(ev.empty)
+
+      override def combine(x: ZManaged[R, E, A], y: ZManaged[R, E, A]): ZManaged[R, E, A] =
+        x.zipWith(y)(ev.combine)(CoreTracer.newTrace)
+    }
+}
+
+sealed trait CatsZManagedInstances1 {
+
+  implicit def monadZManagedInstances[R, E]: Monad[ZManaged[R, E, *]] = new CatsZManagedMonad
+
+  implicit def semigroupZManagedInstances[R, E, A](implicit ev: Semigroup[A]): Semigroup[ZManaged[R, E, A]] =
+    (x: ZManaged[R, E, A], y: ZManaged[R, E, A]) => x.zipWith(y)(ev.combine)(CoreTracer.newTrace)
+
+  implicit def semigroupKZManagedInstances[R, E]: SemigroupK[ZManaged[R, E, *]] = new CatsZManagedSemigroupK
+
+  implicit def bifunctorZManagedInstances[R]: Bifunctor[ZManaged[R, *, *]] = new Bifunctor[ZManaged[R, *, *]] {
+    override def bimap[A, B, C, D](fab: ZManaged[R, A, B])(f: A => C, g: B => D): ZManaged[R, C, D] =
+      fab.mapBoth(f, g)(implicitly[CanFail[A]], InteropTracer.newTrace(f))
+  }
+}
+
+private class CatsZManagedMonad[R, E] extends Monad[ZManaged[R, E, *]] {
+  override def pure[A](x: A): ZManaged[R, E, A] = ZManaged.succeedNow(x)
+
+  override def flatMap[A, B](fa: ZManaged[R, E, A])(f: A => ZManaged[R, E, B]): ZManaged[R, E, B] =
+    fa.flatMap(f)(InteropTracer.newTrace(f))
+
+  override def tailRecM[A, B](a: A)(f: A => ZManaged[R, E, Either[A, B]]): ZManaged[R, E, B] = {
+    implicit def tracer: Trace = InteropTracer.newTrace(f)
+
+    ZManaged.suspend(f(a)).flatMap {
+      case Left(nextA) => tailRecM(nextA)(f)
+      case Right(b)    => ZManaged.succeedNow(b)
+    }
+  }
+}
+
+private class CatsZManagedMonadError[R, E] extends CatsZManagedMonad[R, E] with MonadError[ZManaged[R, E, *], E] {
+  override def raiseError[A](e: E): ZManaged[R, E, A] = {
+    implicit def tracer: Trace = CoreTracer.newTrace
+
+    ZManaged.fromZIO(ZIO.fail(e))
+  }
+
+  override def handleErrorWith[A](fa: ZManaged[R, E, A])(f: E => ZManaged[R, E, A]): ZManaged[R, E, A] =
+    fa.catchAll(f)(implicitly[CanFail[E]], InteropTracer.newTrace(f))
+}
+
+/**
+ * lossy, throws away errors using the "first success" interpretation of SemigroupK
+ */
+private class CatsZManagedSemigroupK[R, E] extends SemigroupK[ZManaged[R, E, *]] {
+  override def combineK[A](x: ZManaged[R, E, A], y: ZManaged[R, E, A]): ZManaged[R, E, A] =
+    x.orElse(y)(implicitly[CanFail[E]], CoreTracer.newTrace)
+}
+
+private class CatsZManagedSync[R] extends CatsZManagedMonadError[R, Throwable] with Sync[ZManaged[R, Throwable, *]] {
+
+  override final def delay[A](thunk: => A): ZManaged[R, Throwable, A] = {
+    val byName: () => A                = () => thunk
+    implicit def tracer: Trace = InteropTracer.newTrace(byName)
+
+    ZManaged.fromZIO(ZIO.attempt(thunk))
+  }
+
+  override final def suspend[A](thunk: => ZManaged[R, Throwable, A]): ZManaged[R, Throwable, A] = {
+    val byName: () => ZManaged[R, Throwable, A] = () => thunk
+    implicit def tracer: Trace          = InteropTracer.newTrace(byName)
+
+    ZManaged.unwrap(ZIO.attempt(thunk))
+  }
+
+  override def bracketCase[A, B](
+                                  acquire: ZManaged[R, Throwable, A]
+                                )(use: A => ZManaged[R, Throwable, B])(
+                                  release: (A, cats.effect.ExitCase[Throwable]) => ZManaged[R, Throwable, Unit]
+                                ): ZManaged[R, Throwable, B] = {
+    implicit def tracer: Trace = InteropTracer.newTrace(use)
+
+    ZManaged {
+      ZIO.uninterruptibleMask { restore =>
+        (for {
+          a     <- acquire
+          exitB <- ZManaged(restore(use(a).zio)).exit
+          _     <- release(a, exitToExitCase(exitB))
+          b     <- ZManaged.done(exitB)
+        } yield b).zio
+      }
+    }
+  }
 }


### PR DESCRIPTION
This is pretty much just bringing back what was already defined for CE 2. I didn't wanted to split that into multiple classes to make it the same as it's currently defined for CE3.
