### PR TITLE
Publish compat lib for ZIO 2.0, Scala.js, and Scala 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .bloop
 .metals
+metals.sbt
 project/.sbt
 project/travis-deploy-key
 project/secrets.tar.xz
@@ -7,3 +8,5 @@ project/zecret
 target
 test-output/
 .idea/
+.bsp
+.vscode

--- a/build.sbt
+++ b/build.sbt
@@ -47,7 +47,7 @@ lazy val root = project
     unusedCompileDependenciesFilter -= moduleFilter("org.scala-js", "scalajs-library")
   )
 
-val zioVersion                 = "2.0.0"
+val zioVersion                 = "2.0.1"
 val catsVersion                = "2.8.0"
 val catsEffectVersion          = "3.2.9"
 val catsMtlVersion             = "1.2.1"

--- a/build.sbt
+++ b/build.sbt
@@ -78,6 +78,7 @@ lazy val zioInteropCats = crossProject(JSPlatform, JVMPlatform)
 lazy val zioInteropCatsJVM = zioInteropCats.jvm.settings(dottySettings)
 
 lazy val zioInteropCatsJS = zioInteropCats.js
+  .settings(dottySettings)
   .settings(libraryDependencies += "io.github.cquiroz" %%% "scala-java-time" % scalaJavaTimeVersion % Test)
 
 lazy val zioInteropCatsTests = crossProject(JSPlatform, JVMPlatform)
@@ -112,6 +113,7 @@ lazy val zioInteropCatsTests = crossProject(JSPlatform, JVMPlatform)
 lazy val zioInteropCatsTestsJVM = zioInteropCatsTests.jvm.settings(dottySettings)
 
 lazy val zioInteropCatsTestsJS = zioInteropCatsTests.js
+  .settings(dottySettings)
   .settings(libraryDependencies += "io.github.cquiroz" %%% "scala-java-time" % scalaJavaTimeVersion % Test)
 
 lazy val zioTestInteropCats = crossProject(JSPlatform, JVMPlatform)
@@ -148,6 +150,7 @@ lazy val zioTestInteropCats = crossProject(JSPlatform, JVMPlatform)
 lazy val zioTestInteropCatsJVM = zioTestInteropCats.jvm.settings(dottySettings)
 
 lazy val zioTestInteropCatsJS = zioTestInteropCats.js
+  .settings(dottySettings)
   .settings(libraryDependencies += "io.github.cquiroz" %%% "scala-java-time" % scalaJavaTimeVersion % Test)
 
 lazy val coreOnlyTest = crossProject(JSPlatform, JVMPlatform)
@@ -167,4 +170,5 @@ lazy val coreOnlyTest = crossProject(JSPlatform, JVMPlatform)
 lazy val coreOnlyTestJVM = coreOnlyTest.jvm.settings(dottySettings)
 
 lazy val coreOnlyTestJS = coreOnlyTest.js
+  .settings(dottySettings)
   .settings(libraryDependencies += "io.github.cquiroz" %%% "scala-java-time" % scalaJavaTimeVersion % Test)

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -45,13 +45,15 @@ object BuildHelper {
     buildInfoObject  := "BuildInfoInteropCats"
   )
 
-  val optimizerOptions =
-    Seq(
-      "-opt:l:inline",
-      "-opt-inline-from:zio.interop.**"
-    )
+  def optimizerOptions(optimize: Boolean) =
+    if(optimize) {
+      Seq(
+        "-opt:l:inline",
+        "-opt-inline-from:zio.interop.**"
+      )
+    } else Nil
 
-  def extraOptions(scalaVersion: String) =
+  def extraOptions(scalaVersion: String, optimize: Boolean) =
     CrossVersion.partialVersion(scalaVersion) match {
       case Some((3, 1))  =>
         std3xOptions
@@ -61,7 +63,7 @@ object BuildHelper {
           "-Wnumeric-widen",
           "-Wunused:_",
           "-Wvalue-discard"
-        ) ++ std2xOptions ++ optimizerOptions
+        ) ++ std2xOptions ++ optimizerOptions(optimize)
       case Some((2, 12)) =>
         Seq(
           "-opt-warnings",
@@ -73,16 +75,15 @@ object BuildHelper {
           "-Ywarn-inaccessible",
           "-Ywarn-nullary-override",
           "-Ywarn-nullary-unit"
-        ) ++ std2xOptions ++ optimizerOptions
+        ) ++ std2xOptions ++ optimizerOptions(optimize)
       case _             => Seq.empty
     }
 
   def stdSettings(prjName: String) = Seq(
     name                     := s"$prjName",
-    scalacOptions            := stdOptions,
     crossScalaVersions       := Seq(Scala213, Scala212),
     ThisBuild / scalaVersion := crossScalaVersions.value.head,
-    scalacOptions            := stdOptions ++ extraOptions(scalaVersion.value),
+    scalacOptions            ++= stdOptions ++ extraOptions(scalaVersion.value, optimize = !isSnapshot.value),
     libraryDependencies ++= testDeps ++ {
       if (isDotty(scalaVersion.value)) Seq.empty
       else Seq(compilerPlugin("org.typelevel" % "kind-projector" % "0.13.2") cross CrossVersion.full)

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -46,7 +46,7 @@ object BuildHelper {
   )
 
   def optimizerOptions(optimize: Boolean) =
-    if(optimize) {
+    if (optimize) {
       Seq(
         "-opt:l:inline",
         "-opt-inline-from:zio.interop.**"
@@ -83,7 +83,7 @@ object BuildHelper {
     name                     := s"$prjName",
     crossScalaVersions       := Seq(Scala213, Scala212),
     ThisBuild / scalaVersion := crossScalaVersions.value.head,
-    scalacOptions            ++= stdOptions ++ extraOptions(scalaVersion.value, optimize = !isSnapshot.value),
+    scalacOptions ++= stdOptions ++ extraOptions(scalaVersion.value, optimize = !isSnapshot.value),
     libraryDependencies ++= testDeps ++ {
       if (isDotty(scalaVersion.value)) Seq.empty
       else Seq(compilerPlugin("org.typelevel" % "kind-projector" % "0.13.2") cross CrossVersion.full)

--- a/zio-interop-cats-tests/shared/src/test/scala/zio/interop/CatsSpecBase.scala
+++ b/zio-interop-cats-tests/shared/src/test/scala/zio/interop/CatsSpecBase.scala
@@ -72,7 +72,7 @@ private[zio] trait CatsSpecBase
   def unsafeRun[E, A](io: IO[E, A])(implicit ticker: Ticker): Exit[E, Option[A]] =
     try {
       var exit: Exit[E, Option[A]] = Exit.succeed(Option.empty[A])
-      Unsafe.unsafeCompat { implicit u =>
+      Unsafe.unsafe { implicit u =>
         val fiber = runtime.unsafe.fork[E, Option[A]](io.asSome)
         fiber.unsafe.addObserver(exit = _)
       }
@@ -87,7 +87,7 @@ private[zio] trait CatsSpecBase
   implicit def runtime(implicit ticker: Ticker): Runtime[Any] = {
     val executor         = Executor.fromExecutionContext(ticker.ctx)
     val blockingExecutor = Executor.fromExecutionContext(ticker.ctx)
-    val fiberId          = Unsafe.unsafeCompat(implicit u => FiberId.make(Trace.empty))
+    val fiberId          = Unsafe.unsafe(implicit u => FiberId.make(Trace.empty))
     val fiberRefs        = FiberRefs(
       Map(
         FiberRef.overrideExecutor        -> ::(fiberId -> Some(executor), Nil),

--- a/zio-interop-cats/shared/src/main/scala/zio/interop/package.scala
+++ b/zio-interop-cats/shared/src/main/scala/zio/interop/package.scala
@@ -71,7 +71,7 @@ package object interop {
     rio: RIO[R, A]
   )(implicit R: Runtime[R], F: Async[F], trace: Trace): F[A] =
     F.uncancelable { poll =>
-      Unsafe.unsafeCompat { implicit u =>
+      Unsafe.unsafe { implicit u =>
         F.delay(R.unsafe.runToFuture(rio)).flatMap { future =>
           poll(F.onCancel(F.fromFuture(F.pure[Future[A]](future)), F.fromFuture(F.delay(future.cancel())).void))
         }

--- a/zio-interop-cats/shared/src/main/scala/zio/interop/stm/STM.scala
+++ b/zio-interop-cats/shared/src/main/scala/zio/interop/stm/STM.scala
@@ -179,7 +179,7 @@ object STM {
 
   final def atomically[F[+_], A](stm: => STM[F, A])(implicit R: Runtime[Any], F: Async[F], trace: Trace): F[A] =
     F.async_ { cb =>
-      Unsafe.unsafeCompat { implicit u =>
+      Unsafe.unsafe { implicit u =>
         val fiber = R.unsafe.fork(ZSTM.atomically(stm.underlying))
         fiber.unsafe.addObserver { exit =>
           cb(exit.toEither)

--- a/zio-test-interop-cats/shared/src/test/scala/zio/test/interop/CatsRunnableSpec.scala
+++ b/zio-test-interop-cats/shared/src/test/scala/zio/test/interop/CatsRunnableSpec.scala
@@ -18,7 +18,7 @@ abstract class CatsRunnableSpec extends ZIOSpecDefault {
   implicit val cioRuntime: IORuntime =
     Scheduler.createDefaultScheduler() match {
       case (scheduler, shutdown) =>
-        Unsafe.unsafeCompat { implicit u =>
+        Unsafe.unsafe { implicit u =>
           val ec = zioRuntime.unsafe.run(ZIO.executor.map(_.asExecutionContext)).getOrThrowFiberFailure()
           IORuntime(ec, ec, scheduler, shutdown, IORuntimeConfig())
         }
@@ -29,7 +29,7 @@ abstract class CatsRunnableSpec extends ZIOSpecDefault {
       openDispatcher.unsafeToFutureCancelable(fa)
   }
 
-  Unsafe.unsafeCompat { implicit u =>
+  Unsafe.unsafe { implicit u =>
     runtime.unsafe.runToFuture {
       ZIO.fromFuture { implicit ec =>
         Dispatcher[CIO].allocated.unsafeToFuture().andThen { case Success((dispatcher, close)) =>


### PR DESCRIPTION
Issue reference: https://github.com/zio/interop-cats/issues/596

The work here is based on the work done in two other PRs:

This was the template for the actual needed change as advised by @neko-kai:
https://github.com/zio/interop-cats/pull/600

This was required for local testing to be possible:
https://github.com/zio/zio/pull/5238

I also bumped to ZIO 2.0.1 and added VSCode + Metals entires to .gitignore.

I have tested this locally and it appears to work as intended.
