### PR TITLE
README: Clarify that the Task alias exists already

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ libraryDependencies += "dev.zio" %% "zio-interop-cats" % "<check-badge-for-lates
 **ZIO** integrates with Typelevel libraries by providing an instance of `Concurrent`, `Temporal` and `Async` for `Task` 
 as required, for instance, by `fs2`, `doobie` and `http4s`.
 
-For convenience, we have defined an alias as follows:
+For convenience, the ZIO library defines an alias as follows:
 
 ```scala
 type Task[A] = ZIO[Any, Throwable, A]


### PR DESCRIPTION
I thought the wording implied that the alias needed to be defined at the point of use (i.e. that it had been defined for the purposes of the examples below), not that it conveniently already existed as was ready for use.

If you don't feel the clarification is necessary, by all means close this suggested change without merging. Just trying to be helpful. :smile: 