### PR TITLE
chore: zio 2.0.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -49,7 +49,7 @@ lazy val root = project
     unusedCompileDependenciesFilter -= moduleFilter("org.scala-js", "scalajs-library")
   )
 
-val zioVersion                 = "2.0.11"
+val zioVersion                 = "2.0.13"
 val catsVersion                = "2.9.0"
 val catsEffectVersion          = "3.4.8"
 val catsMtlVersion             = "1.3.0"


### PR DESCRIPTION
Getting `NoSuchMethodError` on `ZIO.unsafe.makeChildFiber` in a downstream project when trying to bump the ZIO version.