### PR TITLE
Update Cats Effect (3.5.x) and FS2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -53,10 +53,10 @@ lazy val root = project
 
 val zioVersion                 = "2.0.21"
 val catsVersion                = "2.9.0"
-val catsEffectVersion          = "3.4.8"
+val catsEffectVersion          = "3.5.3"
 val catsMtlVersion             = "1.3.0"
 val disciplineScalaTestVersion = "2.2.0"
-val fs2Version                 = "3.6.1"
+val fs2Version                 = "3.9.4"
 val scalaJavaTimeVersion       = "2.5.0"
 
 lazy val zioInteropTracer = crossProject(JSPlatform, JVMPlatform)

--- a/zio-interop-cats-tests/jvm/src/test/scala/zio/interop/fs2StreamSpec.scala
+++ b/zio-interop-cats-tests/jvm/src/test/scala/zio/interop/fs2StreamSpec.scala
@@ -14,7 +14,7 @@ object fs2StreamSpec extends ZIOSpecDefault {
   val exception: Throwable = new Exception("Failed")
 
   def fs2StreamFromChunk[A](chunk: Chunk[A]) =
-    fs2.Stream.chunk[Task, A](fs2.Chunk.indexedSeq(chunk))
+    fs2.Stream.chunk[Task, A](fs2.Chunk.from(chunk))
 
   def assertEqual[A](actual: fs2.Stream[Task, A], expected: fs2.Stream[Task, A]) =
     for {

--- a/zio-interop-cats/shared/src/main/scala/zio/stream/interop/FS2StreamSyntax.scala
+++ b/zio-interop-cats/shared/src/main/scala/zio/stream/interop/FS2StreamSyntax.scala
@@ -25,7 +25,7 @@ class ZStreamSyntax[R, E, A](private val stream: ZStream[R, E, A]) extends AnyVa
 
     fs2.Stream.resource(Resource.scopedZIO[R, E, ZIO[R, Option[E], Chunk[A]]](stream.toPull)).flatMap { pull =>
       fs2.Stream.repeatEval(pull.unsome).unNoneTerminate.flatMap { chunk =>
-        fs2.Stream.chunk(fs2.Chunk.indexedSeq(chunk))
+        fs2.Stream.chunk(fs2.Chunk.from(chunk))
       }
     }
   }


### PR DESCRIPTION
- Update Cats Effect to 3.5.3
- Update FS2 to 3.9.4 and use updated APIs

Memory usage continues to be stable with the update to the latest Cats Effect 3.5.x version 

```scala
libraryDependencies ++= 
  Seq(
    "dev.zio"         %% "zio"               % "2.0.21",
    "dev.zio"         %% "zio-interop-cats"  % "23.1.0.1+0-660c3b77+20240218-1931-SNAPSHOT",
    "dev.zio"         %% "zio-logging-slf4j" % "2.2.0",
    "com.github.fd4s" %% "fs2-kafka"         % "3.2.0",
    "ch.qos.logback"   % "logback-classic"   % "1.4.14"
  )
```

```scala
import fs2.Stream
import fs2.kafka.*
import zio.{durationInt as _, *}
import zio.interop.catz.*
import zio.logging.backend.SLF4J

import scala.concurrent.duration.*

object ReproducerFs2KafkaZIO extends ZIOAppDefault:
  override val bootstrap: ZLayer[ZIOAppArgs, Any, Any] =
    Runtime.removeDefaultLoggers ++ SLF4J.slf4j

  val topic = "example-topic"

  val consumer: Stream[Task, Unit] =
    val settings =
      ConsumerSettings[Task, String, String]
        .withBootstrapServers("localhost:9092")
        .withGroupId("test-consumer-group-id-2")
        .withAutoOffsetReset(AutoOffsetReset.Earliest)

    KafkaConsumer
      .stream[Task, String, String](settings)
      .evalTap(_.subscribeTo(topic))
      .stream
      .mapChunks(_.map(_.offset))
      .through(commitBatchWithin[Task](2048, 10.seconds))

  val producer: Stream[Task, ProducerResult[String, String]] =
    val settings =
      ProducerSettings[Task, String, String]
        .withBootstrapServers("localhost:9092")
        .withBatchSize(128)
        .withAcks(Acks.One)
        .withEnableIdempotence(false)
        .withRetries(128)

    val producerPipe = KafkaProducer.pipe[Task, String, String](settings)

    Stream
      .iterate[Task, Long](0L)(_ + 1L)
      .map(n => ProducerRecord(topic = topic, key = s"key: $n", value = s"value: $n"))
      .chunkN(n = 128, allowFewer = true)
      .map(ProducerRecords[fs2.Chunk, String, String])
      .through(producerPipe)

  override val run: Task[Unit] =
    Stream(producer, consumer).parJoinUnbounded.compile.drain
```

<img width="1339" alt="image" src="https://github.com/zio/interop-cats/assets/14280155/0d0acf3c-61e8-4552-a553-8904e7a069d9">
