### PR TITLE
Use `FiberRuntime#unsafe.addObserver` for bincompat with v2.1

### DIFF
--- a/zio-interop-cats/shared/src/main/scala/zio/interop/cats.scala
+++ b/zio-interop-cats/shared/src/main/scala/zio/interop/cats.scala
@@ -431,12 +431,12 @@ private abstract class ZioConcurrent[R, E, E1]
       ZIO
         .async[R, E3, C](
           { cb =>
-            leftFiber.addObserver { _ =>
+            leftFiber.unsafe.addObserver { _ =>
               complete(leftFiber, rightFiber, leftWins, raceIndicator, cb)
               ()
             }(Unsafe.unsafe)
 
-            rightFiber.addObserver { _ =>
+            rightFiber.unsafe.addObserver { _ =>
               complete(rightFiber, leftFiber, rightWins, raceIndicator, cb)
               ()
             }(Unsafe.unsafe)


### PR DESCRIPTION
To avoid bincompat issues with 2.1.x versions  (see https://github.com/zio/zio/pull/8757)