### PR TITLE
Fix propagation of interruption from CIO to ZIO

### DIFF
--- a/zio-interop-cats/shared/src/main/scala/zio/interop/package.scala
+++ b/zio-interop-cats/shared/src/main/scala/zio/interop/package.scala
@@ -54,7 +54,7 @@ package object interop {
                   fiber.unsafe.removeObserver(completeCb)
                   fiber.tellInterrupt(Cause.interrupt(fiber.id))
                   // Allow the interruption to be interrupted
-                  Some(fiber.unsafe.removeObserver(interruptCb))
+                  Some(F.delay(fiber.unsafe.removeObserver(interruptCb)))
                 }
               }))
             case Right(v)    => Right(v) // No need to invoke the callback, sync resumption will take place

--- a/zio-interop-cats/shared/src/main/scala/zio/interop/package.scala
+++ b/zio-interop-cats/shared/src/main/scala/zio/interop/package.scala
@@ -54,7 +54,10 @@ package object interop {
                   fiber.unsafe.removeObserver(completeCb)
                   fiber.tellInterrupt(Cause.interrupt(fiber.id))
                   // Allow the interruption to be interrupted
-                  Some(F.delay(fiber.unsafe.removeObserver(interruptCb)))
+                  Some(F.delay {
+                    fiber.unsafe.removeObserver(interruptCb)
+                    interruptCb(null)
+                  })
                 }
               }))
             case Right(v)    => Right(v) // No need to invoke the callback, sync resumption will take place


### PR DESCRIPTION
/claim #695
/fixes #695

Reopening #696 since the bounty claim wasn't working

Note that I also changed the code to use runOrFork instead of fork within toEffect. This is to avoid the overhead of forking fibers when the ZIO effect can be evaluated synchronously. Users that convert simple ZIO effects to CIO often will see a very notable performance improvement from this change.