### PR TITLE
Use microseconds in realTime, aligned with cats impl

### DIFF
--- a/zio-interop-cats/shared/src/main/scala/zio/interop/cats.scala
+++ b/zio-interop-cats/shared/src/main/scala/zio/interop/cats.scala
@@ -556,7 +556,7 @@ private abstract class ZioTemporal[R, E, E1] extends ZioConcurrent[R, E, E1] wit
   override def realTime: F[FiniteDuration] = {
     implicit def trace: Trace = CoreTracer.newTrace
 
-    currentTime(NANOSECONDS).map(FiniteDuration(_, NANOSECONDS))
+    currentTime(MICROSECONDS).map(FiniteDuration(_, MICROSECONDS))
   }
 }
 


### PR DESCRIPTION
Related https://github.com/zio/interop-cats/issues/699
cats IO returns microsecond precision https://github.com/typelevel/cats-effect/blob/7102a235fd8beeeb8b13131552706c4127b0fb7a/core/shared/src/main/scala/cats/effect/IOFiber.scala#L295