### PR TITLE
Follow up #705, use ZIO.onExit instead of fs2.Stream.onFinalizeCase to more robustly catch all cases

### DIFF
--- a/zio-interop-cats-tests/jvm/src/test/scala/zio/interop/fs2StreamSpec.scala
+++ b/zio-interop-cats-tests/jvm/src/test/scala/zio/interop/fs2StreamSpec.scala
@@ -65,7 +65,7 @@ object fs2StreamSpec extends ZIOSpecDefault {
       },
       test("unguarded throw propagation") {
         val result = (Stream[Task, Int](1, 2, 3) ++ (throw exception)).toZStream().runDrain.exit
-        assertZIO(result)(fails(equalTo(exception)))
+        assertZIO(result)(dies(equalTo(exception)))
       },
       test("releases all resources by the time the failover stream has started") {
         for {


### PR DESCRIPTION
I thought that interruption inheritance could've caused hangs in #705 when .resource.drain.toScopedZIO was used. That doesn't seem to be the case, instead termination happened before onFinalizeCase error handler was installed. Using native ZIO onExit prevents that from happening and also prevents conversion of Cause.Die to Cause.Error.