### PR TITLE
Move uninterruptibleMask outside of ZIO.acquireReleaseExit in toScopedZIO

### DIFF
--- a/zio-interop-cats/shared/src/main/scala/zio/interop/catszmanaged.scala
+++ b/zio-interop-cats/shared/src/main/scala/zio/interop/catszmanaged.scala
@@ -71,11 +71,11 @@ final class ZIOResourceSyntax[R, E <: Throwable, A](private val resource: Resour
     def go[B](resource: Resource[F, B]): ZIO[R with Scope, E, B] =
       resource match {
         case allocate: Resource.Allocate[F, b] =>
-          ZIO.acquireReleaseExit {
-            ZIO.uninterruptibleMask { restore =>
+          ZIO.uninterruptibleMask { restore =>
+            ZIO.acquireReleaseExit {
               allocate.resource(toPoll(restore))
-            }
-          } { case ((_, release), exit) => toExitCaseThisFiber(exit).flatMap(t => release(t)).orDie }.map(_._1)
+            } { case ((_, release), exit) => toExitCaseThisFiber(exit).flatMap(t => release(t)).orDie }.map(_._1)
+          }
 
         case bind: Resource.Bind[F, a, B] =>
           go(bind.source).flatMap(a => go(bind.fs(a)))


### PR DESCRIPTION
The `restore` before this change must've been a no-op, since it was created inside an uninterruptible section