### PR TITLE
CI: Drop JDK 11, add JDK 25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,9 +76,9 @@ jobs:
       fail-fast: false
       matrix:
         java:
-        - '11'
         - '17'
         - '21'
+        - '25'
     steps:
     - name: Install libuv
       run: sudo apt-get update && sudo apt-get install -y libuv1-dev

--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -1,0 +1,27 @@
+name: Scala Steward
+
+# This workflow will launch every day at 00:00
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  scala-steward:
+    timeout-minutes: 45
+    runs-on: ubuntu-latest
+    name: Scala Steward
+    steps:
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
+      - name: Scala Steward
+        uses: scala-steward-org/scala-steward-action@v2
+        with:
+          github-app-id: ${{ secrets.SCALA_STEWARD_GITHUB_APP_ID }}
+          github-app-installation-id: ${{ secrets.SCALA_STEWARD_GITHUB_APP_INSTALLATION_ID }}
+          github-app-key: ${{ secrets.SCALA_STEWARD_GITHUB_APP_PRIVATE_KEY }}
+          github-app-auth-only: true


### PR DESCRIPTION
## Summary
- Drop JDK 11 from the CI test matrix
- Add JDK 25 to the CI test matrix
- Test matrix is now: JDK 17, 21, 25